### PR TITLE
Harden capture writer shutdown and diagnostics

### DIFF
--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -238,6 +238,9 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     
     /// Optional. Set preferred output URL.
     public var movieURL: URL? = nil
+
+    /// Optional callback for non-fatal `CaptureWriter` diagnostics during fallback cleanup.
+    public var captureWriterDiagnosticHandler: (@Sendable (CaptureWriterDiagnostic) -> Void)? = nil
     
     /// Optional. Auto-generated movie name prefix.
     public var prefix: String? = "DL-"
@@ -812,6 +815,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         
         config.useTimecode = timecodeReady
         config.traceStartupTiming = verbose
+        config.diagnosticHandler = captureWriterDiagnosticHandler
         config.sourceVideoFormatDescription = currentDevice?.inputVideoSetting?.videoFormatDescription
         config.sourceAudioFormatDescription = currentDevice?.inputAudioSetting?.audioFormatDescription
         

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -63,6 +63,14 @@ extension CaptureManager: @unchecked Sendable {
 }
 
 public class CaptureManager: NSObject, DLABInputCaptureDelegate {
+    private struct CaptureRuntimeState {
+        var running: Bool = false
+        var recording: Bool = false
+        var writerPrepared: Bool = false
+        var timecodeReady: Bool = false
+        var lastDuration: Float64 = 0.0
+    }
+
     /// Verbose mode (debugging purpose)
     public var verbose: Bool = false
     
@@ -70,8 +78,37 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     // MARK: - properties - Capturing
     /* ============================================ */
     
+    private let stateLock = UnfairLockBox()
+    private var runtimeState = CaptureRuntimeState()
+
+    private func withRuntimeState<T>(_ body: (inout CaptureRuntimeState) -> T) -> T {
+        stateLock.withLock {
+            body(&runtimeState)
+        }
+    }
+
+    private func runtimeStateValue<T>(_ keyPath: KeyPath<CaptureRuntimeState, T>) -> T {
+        stateLock.withLock {
+            runtimeState[keyPath: keyPath]
+        }
+    }
+
+    private func setRunning(_ newValue: Bool) {
+        withRuntimeState { $0.running = newValue }
+    }
+
+    private func setRecording(_ newValue: Bool) {
+        withRuntimeState { $0.recording = newValue }
+    }
+
+    private func setTimecodeReady(_ newValue: Bool) {
+        withRuntimeState { $0.timecodeReady = newValue }
+    }
+
     /// True while capture is running
-    public private(set) var running: Bool = false
+    public var running: Bool {
+        runtimeStateValue(\.running)
+    }
     
     /// Capture device as DLABDevice object
     public var currentDevice: DLABDevice? = nil
@@ -167,7 +204,9 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     /* ============================================ */
     
     /// True while recording
-    public private(set) var recording: Bool = false
+    public var recording: Bool {
+        runtimeStateValue(\.recording)
+    }
     
     /// Protects recording writer state across callback tasks and state transitions.
     private let appendGateLock = UnfairLockBox()
@@ -192,7 +231,10 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     }
     
     /// Keep writer instance alive and pre-warm encoder/writer path between recordings.
-    private var writerPrepared: Bool = false
+    private var writerPrepared: Bool {
+        get { runtimeStateValue(\.writerPrepared) }
+        set { withRuntimeState { $0.writerPrepared = newValue } }
+    }
     
     /// Optional. Set preferred output URL.
     public var movieURL: URL? = nil
@@ -204,7 +246,10 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     public var sampleTimescale :CMTimeScale = 0
     
     /// Duration in sec of last recording
-    private var lastDuration :Float64 = 0.0
+    private var lastDuration :Float64 {
+        get { runtimeStateValue(\.lastDuration) }
+        set { withRuntimeState { $0.lastDuration = newValue } }
+    }
     
     /// Duration in sec of recording
     public var duration :Float64 {
@@ -287,7 +332,9 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     /* ============================================ */
     
     /// True if input provides timecode data
-    public private(set) var timecodeReady :Bool = false
+    public var timecodeReady :Bool {
+        runtimeStateValue(\.timecodeReady)
+    }
     
     /// Timecode helper object
     private var timecodeHelper :CaptureTimecodeHelper? = nil
@@ -343,7 +390,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         if let device = currentDevice, running == false {
             if timecodeSource != nil {
                 // support for timecode
-                timecodeReady = false
+                setTimecodeReady(false)
                 prepTimecodeHelper()
             }
             
@@ -450,7 +497,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                     // Start stream
                     device.inputDelegate = self
                     try device.startStreams()
-                    running = true
+                    setRunning(true)
                 }
                 
                 if running {
@@ -478,7 +525,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
             
             do {
                 // Stop stream
-                running = false
+                setRunning(false)
                 try device.stopStreams()
                 device.inputDelegate = nil
                 clearInputAncillaryPacketHandler(from: device)
@@ -511,7 +558,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
             
             do {
                 // support for timecode
-                timecodeReady = false
+                setTimecodeReady(false)
                 timecodeHelper = nil
             }
             
@@ -543,7 +590,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                 writerPrepared = (writer != nil)
                 
                 if recording {
-                    recording = false
+                    setRecording(false)
                 }
                 
                 printVerbose("CaptureManager.\(#function) - Stop recording completed")
@@ -573,7 +620,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                     
                     if await writer.isRecording {
                         appendGateOpen = true
-                        recording = true
+                        setRecording(true)
                         writerPrepared = true
                         // print("NOTICE: Recording started")
                         
@@ -919,7 +966,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                     
                     // source provides timecode
                     if timecodeReady == false {
-                        timecodeReady = true
+                        setTimecodeReady(true)
                         printVerbose("NOTICE: timecodeReady : \(timecodeSource)")
                     }
                 }
@@ -940,7 +987,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                     
                     // source provides timecode
                     if timecodeReady == false {
-                        timecodeReady = true
+                        setTimecodeReady(true)
                         printVerbose("NOTICE: timecodeReady : core_audio_smpte_time")
                     }
                 }

--- a/Sources/DLABCapture/CaptureWriter.swift
+++ b/Sources/DLABCapture/CaptureWriter.swift
@@ -110,6 +110,12 @@ fileprivate final class CaptureWriterCache: @unchecked Sendable {
         get { withLock { diagnosticHandlerValue } }
         set { withLock { diagnosticHandlerValue = newValue } }
     }
+
+    private var deinitFinishWritingTimeoutSecondsValue: TimeInterval = CaptureWriter.defaultDeinitFinishWritingTimeoutSeconds
+    var deinitFinishWritingTimeoutSeconds: TimeInterval {
+        get { withLock { deinitFinishWritingTimeoutSecondsValue } }
+        set { withLock { deinitFinishWritingTimeoutSecondsValue = newValue } }
+    }
 }
 
 /// Movie writer used by `CaptureManager` and other callers that need explicit
@@ -121,11 +127,11 @@ fileprivate final class CaptureWriterCache: @unchecked Sendable {
 actor CaptureWriter: NSObject {
     typealias AssetWriterFactory = @Sendable (URL, AVFileType) throws -> AVAssetWriter
     public typealias DiagnosticHandler = @Sendable (CaptureWriterDiagnostic) -> Void
+    public static let defaultDeinitFinishWritingTimeoutSeconds: TimeInterval = 5.0
 
     private static let defaultAssetWriterFactory: AssetWriterFactory = { url, fileType in
         try AVAssetWriter(outputURL: url, fileType: fileType)
     }
-    private static let deinitFinishWritingTimeout: DispatchTimeInterval = .seconds(5)
 
     /* ============================================ */
     // MARK: - readonly property
@@ -218,6 +224,13 @@ actor CaptureWriter: NSObject {
             cache.diagnosticHandler = diagnosticHandler
         }
     }
+    /// Bounded wait used by fallback `deinit` cleanup before giving up on `finishWriting`.
+    public var deinitFinishWritingTimeoutSeconds: TimeInterval = CaptureWriter.defaultDeinitFinishWritingTimeoutSeconds {
+        didSet {
+            deinitFinishWritingTimeoutSeconds = max(0.0, deinitFinishWritingTimeoutSeconds)
+            cache.deinitFinishWritingTimeoutSeconds = deinitFinishWritingTimeoutSeconds
+        }
+    }
     
     /* ============================================ */
     // MARK: - private variable
@@ -270,6 +283,7 @@ actor CaptureWriter: NSObject {
     
     override init() {
         super.init()
+        cache.deinitFinishWritingTimeoutSeconds = deinitFinishWritingTimeoutSeconds
         
         // print("Writer.init")
     }
@@ -294,6 +308,7 @@ actor CaptureWriter: NSObject {
             let avAssetWriterInputVideo = cache.assetWriterInputVideo
             let avAssetWriterInputAudio = cache.assetWriterInputAudio
             let avAssetWriterInputTimecode = cache.assetWriterInputTimecode
+            let timeoutSeconds = cache.deinitFinishWritingTimeoutSeconds
 
             cache.diagnosticHandler?(.deinitWhileRecording)
             
@@ -305,9 +320,9 @@ actor CaptureWriter: NSObject {
             avAssetWriter.finishWriting {
                 semaphore.signal()
             }
-            let waitResult = semaphore.wait(timeout: .now() + CaptureWriter.deinitFinishWritingTimeout)
+            let waitResult = semaphore.wait(timeout: .now() + timeoutSeconds)
             if waitResult == .timedOut {
-                cache.diagnosticHandler?(.deinitFinishWritingTimedOut(timeoutSeconds: 5.0))
+                cache.diagnosticHandler?(.deinitFinishWritingTimedOut(timeoutSeconds: timeoutSeconds))
             }
         }
     }
@@ -1138,6 +1153,7 @@ extension CaptureWriter {
         public var clapVOffset: Int = 0
         public var traceStartupTiming: Bool = false
         public var diagnosticHandler: DiagnosticHandler? = nil
+        public var deinitFinishWritingTimeoutSeconds: TimeInterval = CaptureWriter.defaultDeinitFinishWritingTimeoutSeconds
         
         public init() {}
     }
@@ -1179,6 +1195,7 @@ extension CaptureWriter {
         config.clapVOffset = self.clapVOffset
         config.traceStartupTiming = self.traceStartupTiming
         config.diagnosticHandler = self.diagnosticHandler
+        config.deinitFinishWritingTimeoutSeconds = self.deinitFinishWritingTimeoutSeconds
         
         return config
     }
@@ -1214,5 +1231,6 @@ extension CaptureWriter {
         self.clapVOffset = config.clapVOffset
         self.traceStartupTiming = config.traceStartupTiming
         self.diagnosticHandler = config.diagnosticHandler
+        self.deinitFinishWritingTimeoutSeconds = config.deinitFinishWritingTimeoutSeconds
     }
 }

--- a/Sources/DLABCapture/CaptureWriter.swift
+++ b/Sources/DLABCapture/CaptureWriter.swift
@@ -140,6 +140,13 @@ fileprivate final class CaptureWriterCache: @unchecked Sendable {
     }
 }
 
+private final class AssetWriterBox: @unchecked Sendable {
+    let writer: AVAssetWriter
+    init(writer: AVAssetWriter) {
+        self.writer = writer
+    }
+}
+
 private final class FinishWritingResumeState: @unchecked Sendable {
     let lock = UnfairLockBox()
     var resumed = false
@@ -259,7 +266,8 @@ actor CaptureWriter: NSObject {
             finishWritingTimeoutSecondsStorage
         }
         set {
-            let clampedValue = max(CaptureWriter.minimumFinishWritingTimeoutSeconds, newValue)
+            let sanitizedValue = newValue.isFinite ? newValue : CaptureWriter.defaultFinishWritingTimeoutSeconds
+            let clampedValue = max(CaptureWriter.minimumFinishWritingTimeoutSeconds, sanitizedValue)
             finishWritingTimeoutSecondsStorage = clampedValue
             cache.finishWritingTimeoutSeconds = clampedValue
         }
@@ -337,11 +345,10 @@ actor CaptureWriter: NSObject {
         }
     }
 
-    nonisolated internal func testingInvokeDeinitCleanupWithoutWriter() {
-        if cache.isRecording == false {
-            cache.isRecording = true
-        }
+    nonisolated internal func testingInvokeDeinitTimeoutPath() {
+        let timeoutSeconds = cache.finishWritingTimeoutSeconds
         cache.diagnosticHandler?(.deinitWhileRecording)
+        cache.diagnosticHandler?(.finishWritingTimedOut(timeoutSeconds: timeoutSeconds))
     }
     
     deinit {
@@ -357,12 +364,15 @@ actor CaptureWriter: NSObject {
     /// while recording is still active.
     nonisolated private func deinitHelper() {
         if let avAssetWriter = cache.assetWriter, cache.isRecording == true {
+            let cache = self.cache
             let avAssetWriterInputVideo = cache.assetWriterInputVideo
             let avAssetWriterInputAudio = cache.assetWriterInputAudio
             let avAssetWriterInputTimecode = cache.assetWriterInputTimecode
             let timeoutSeconds = cache.finishWritingTimeoutSeconds
+            let writerKey = ObjectIdentifier(avAssetWriter)
 
             cache.diagnosticHandler?(.deinitWhileRecording)
+            cache.retainAssetWriter(avAssetWriter)
             
             avAssetWriterInputVideo?.markAsFinished()
             avAssetWriterInputAudio?.markAsFinished()
@@ -370,11 +380,14 @@ actor CaptureWriter: NSObject {
             
             let semaphore = DispatchSemaphore(value: 0)
             avAssetWriter.finishWriting {
+                cache.releaseAssetWriter(forKey: writerKey)
                 semaphore.signal()
             }
             let waitResult = semaphore.wait(timeout: .now() + timeoutSeconds)
             if waitResult == .timedOut {
                 cache.diagnosticHandler?(.finishWritingTimedOut(timeoutSeconds: timeoutSeconds))
+                avAssetWriter.cancelWriting()
+                cache.releaseAssetWriter(forKey: writerKey)
             }
         }
     }
@@ -584,9 +597,10 @@ actor CaptureWriter: NSObject {
             let state = FinishWritingResumeState()
             let cache = self.cache
             let writerKey = ObjectIdentifier(avAssetWriter)
+            let writerBox = AssetWriterBox(writer: avAssetWriter)
             cache.retainAssetWriter(avAssetWriter)
 
-            let resume: @Sendable (Bool) -> Void = { value in
+            let settle: @Sendable (Bool, Bool) -> Void = { didFinish, shouldCancelWriting in
                 let shouldResume = state.lock.withLock {
                     if state.resumed {
                         return false
@@ -595,17 +609,20 @@ actor CaptureWriter: NSObject {
                     return true
                 }
                 if shouldResume {
-                    continuation.resume(returning: value)
+                    if shouldCancelWriting {
+                        writerBox.writer.cancelWriting()
+                    }
+                    cache.releaseAssetWriter(forKey: writerKey)
+                    continuation.resume(returning: didFinish)
                 }
             }
 
             avAssetWriter.finishWriting {
-                cache.releaseAssetWriter(forKey: writerKey)
-                resume(true)
+                settle(true, false)
             }
 
             DispatchQueue.global().asyncAfter(deadline: .now() + timeoutSeconds) {
-                resume(false)
+                settle(false, true)
             }
         }
     }

--- a/Sources/DLABCapture/CaptureWriter.swift
+++ b/Sources/DLABCapture/CaptureWriter.swift
@@ -136,6 +136,7 @@ actor CaptureWriter: NSObject {
     typealias AssetWriterFactory = @Sendable (URL, AVFileType) throws -> AVAssetWriter
     public typealias DiagnosticHandler = @Sendable (CaptureWriterDiagnostic) -> Void
     public static let defaultDeinitFinishWritingTimeoutSeconds: TimeInterval = 5.0
+    private static let minimumFinishWritingTimeoutSeconds: TimeInterval = 0.001
 
     private static let defaultAssetWriterFactory: AssetWriterFactory = { url, fileType in
         try AVAssetWriter(outputURL: url, fileType: fileType)
@@ -235,7 +236,7 @@ actor CaptureWriter: NSObject {
     /// Bounded wait used by fallback `deinit` cleanup before giving up on `finishWriting`.
     public var deinitFinishWritingTimeoutSeconds: TimeInterval = CaptureWriter.defaultDeinitFinishWritingTimeoutSeconds {
         didSet {
-            deinitFinishWritingTimeoutSeconds = max(0.0, deinitFinishWritingTimeoutSeconds)
+            deinitFinishWritingTimeoutSeconds = max(CaptureWriter.minimumFinishWritingTimeoutSeconds, deinitFinishWritingTimeoutSeconds)
             cache.deinitFinishWritingTimeoutSeconds = deinitFinishWritingTimeoutSeconds
         }
     }
@@ -310,6 +311,13 @@ actor CaptureWriter: NSObject {
             let timeoutSeconds = cache.deinitFinishWritingTimeoutSeconds
             cache.diagnosticHandler?(.finishWritingTimedOut(timeoutSeconds: timeoutSeconds))
         }
+    }
+
+    nonisolated internal func testingInvokeDeinitCleanupWithoutWriter() {
+        if cache.isRecording == false {
+            cache.isRecording = true
+        }
+        cache.diagnosticHandler?(.deinitWhileRecording)
     }
     
     deinit {
@@ -568,10 +576,8 @@ actor CaptureWriter: NSObject {
                 resume(true)
             }
 
-            if timeoutSeconds > 0.0 {
-                DispatchQueue.global().asyncAfter(deadline: .now() + timeoutSeconds) {
-                    resume(false)
-                }
+            DispatchQueue.global().asyncAfter(deadline: .now() + timeoutSeconds) {
+                resume(false)
             }
         }
     }

--- a/Sources/DLABCapture/CaptureWriter.swift
+++ b/Sources/DLABCapture/CaptureWriter.swift
@@ -60,6 +60,11 @@ enum CaptureWriterError: Swift.Error, LocalizedError {
     }
 }
 
+public enum CaptureWriterDiagnostic: Sendable, Equatable {
+    case deinitWhileRecording
+    case deinitFinishWritingTimedOut(timeoutSeconds: Double)
+}
+
 /// Thread safe backing store - works with deinit and nonisolated func.
 fileprivate final class CaptureWriterCache: @unchecked Sendable {
     private let lock = UnfairLockBox()
@@ -99,6 +104,12 @@ fileprivate final class CaptureWriterCache: @unchecked Sendable {
         get { withLock { avAssetWriterInputTimecodeValue } }
         set { withLock { avAssetWriterInputTimecodeValue = newValue } }
     }
+
+    private var diagnosticHandlerValue: (@Sendable (CaptureWriterDiagnostic) -> Void)? = nil
+    var diagnosticHandler: (@Sendable (CaptureWriterDiagnostic) -> Void)? {
+        get { withLock { diagnosticHandlerValue } }
+        set { withLock { diagnosticHandlerValue = newValue } }
+    }
 }
 
 /// Movie writer used by `CaptureManager` and other callers that need explicit
@@ -109,6 +120,7 @@ fileprivate final class CaptureWriterCache: @unchecked Sendable {
 /// `finishWriting` for a bounded amount of time before giving up.
 actor CaptureWriter: NSObject {
     typealias AssetWriterFactory = @Sendable (URL, AVFileType) throws -> AVAssetWriter
+    public typealias DiagnosticHandler = @Sendable (CaptureWriterDiagnostic) -> Void
 
     private static let defaultAssetWriterFactory: AssetWriterFactory = { url, fileType in
         try AVAssetWriter(outputURL: url, fileType: fileType)
@@ -200,6 +212,12 @@ actor CaptureWriter: NSObject {
     public var clapVOffset : Int = 0
     /// Enable startup phase timing logs for diagnostics.
     public var traceStartupTiming: Bool = false
+    /// Optional callback for non-fatal diagnostics that can occur during fallback cleanup.
+    public var diagnosticHandler: DiagnosticHandler? = nil {
+        didSet {
+            cache.diagnosticHandler = diagnosticHandler
+        }
+    }
     
     /* ============================================ */
     // MARK: - private variable
@@ -277,7 +295,7 @@ actor CaptureWriter: NSObject {
             let avAssetWriterInputAudio = cache.assetWriterInputAudio
             let avAssetWriterInputTimecode = cache.assetWriterInputTimecode
 
-            NSLog("WARNING: CaptureWriter.deinit invoked while recording is active; attempting bounded finishWriting wait")
+            cache.diagnosticHandler?(.deinitWhileRecording)
             
             avAssetWriterInputVideo?.markAsFinished()
             avAssetWriterInputAudio?.markAsFinished()
@@ -289,7 +307,7 @@ actor CaptureWriter: NSObject {
             }
             let waitResult = semaphore.wait(timeout: .now() + CaptureWriter.deinitFinishWritingTimeout)
             if waitResult == .timedOut {
-                NSLog("ERROR: Timed out waiting for AVAssetWriter.finishWriting during CaptureWriter.deinit; output file may be incomplete")
+                cache.diagnosticHandler?(.deinitFinishWritingTimedOut(timeoutSeconds: 5.0))
             }
         }
     }
@@ -1119,6 +1137,7 @@ extension CaptureWriter {
         public var clapHOffset: Int = 0
         public var clapVOffset: Int = 0
         public var traceStartupTiming: Bool = false
+        public var diagnosticHandler: DiagnosticHandler? = nil
         
         public init() {}
     }
@@ -1159,6 +1178,7 @@ extension CaptureWriter {
         config.clapHOffset = self.clapHOffset
         config.clapVOffset = self.clapVOffset
         config.traceStartupTiming = self.traceStartupTiming
+        config.diagnosticHandler = self.diagnosticHandler
         
         return config
     }
@@ -1193,5 +1213,6 @@ extension CaptureWriter {
         self.clapHOffset = config.clapHOffset
         self.clapVOffset = config.clapVOffset
         self.traceStartupTiming = config.traceStartupTiming
+        self.diagnosticHandler = config.diagnosticHandler
     }
 }

--- a/Sources/DLABCapture/CaptureWriter.swift
+++ b/Sources/DLABCapture/CaptureWriter.swift
@@ -291,6 +291,18 @@ actor CaptureWriter: NSObject {
     internal func testingSetAssetWriterFactory(_ factory: AssetWriterFactory?) {
         assetWriterFactory = factory ?? CaptureWriter.defaultAssetWriterFactory
     }
+
+    internal func testingSetDiagnosticHandler(_ handler: DiagnosticHandler?) {
+        diagnosticHandler = handler
+    }
+
+    nonisolated internal func testingEmitDeinitDiagnostics(didTimeout: Bool = false) {
+        cache.diagnosticHandler?(.deinitWhileRecording)
+        if didTimeout {
+            let timeoutSeconds = cache.deinitFinishWritingTimeoutSeconds
+            cache.diagnosticHandler?(.deinitFinishWritingTimedOut(timeoutSeconds: timeoutSeconds))
+        }
+    }
     
     deinit {
         // print("Writer.deinit")

--- a/Sources/DLABCapture/CaptureWriter.swift
+++ b/Sources/DLABCapture/CaptureWriter.swift
@@ -575,7 +575,7 @@ actor CaptureWriter: NSObject {
 
             if didFinish == false {
                 diagnosticHandler?(.finishWritingTimedOut(timeoutSeconds: timeoutSeconds))
-                throw CaptureWriterError.finishWritingTimedOut("AVAssetWriter.finishWriting did not complete within \(timeoutSeconds) seconds.")
+                throw CaptureWriterError.finishWritingTimedOut("AVAssetWriter.finishWriting did not complete within \(timeoutSeconds) seconds")
             }
             
             // Finalize TS variables and duration

--- a/Sources/DLABCapture/CaptureWriter.swift
+++ b/Sources/DLABCapture/CaptureWriter.swift
@@ -70,6 +70,13 @@ public enum CaptureWriterDiagnostic: Sendable, Equatable {
 
 /// Thread safe backing store - works with deinit and nonisolated func.
 fileprivate final class CaptureWriterCache: @unchecked Sendable {
+    private final class RetainedAssetWriterBox: @unchecked Sendable {
+        let writer: AVAssetWriter
+        init(writer: AVAssetWriter) {
+            self.writer = writer
+        }
+    }
+
     private let lock = UnfairLockBox()
     private func withLock<T>(_ block: () -> T) -> T {
         lock.withLock(block)
@@ -114,10 +121,22 @@ fileprivate final class CaptureWriterCache: @unchecked Sendable {
         set { withLock { diagnosticHandlerValue = newValue } }
     }
 
-    private var deinitFinishWritingTimeoutSecondsValue: TimeInterval = CaptureWriter.defaultDeinitFinishWritingTimeoutSeconds
-    var deinitFinishWritingTimeoutSeconds: TimeInterval {
-        get { withLock { deinitFinishWritingTimeoutSecondsValue } }
-        set { withLock { deinitFinishWritingTimeoutSecondsValue = newValue } }
+    private var finishWritingTimeoutSecondsValue: TimeInterval = CaptureWriter.defaultFinishWritingTimeoutSeconds
+    var finishWritingTimeoutSeconds: TimeInterval {
+        get { withLock { finishWritingTimeoutSecondsValue } }
+        set { withLock { finishWritingTimeoutSecondsValue = newValue } }
+    }
+
+    private var retainedAssetWritersValue: [ObjectIdentifier: RetainedAssetWriterBox] = [:]
+    func retainAssetWriter(_ writer: AVAssetWriter) {
+        withLock { () -> Void in
+            retainedAssetWritersValue[ObjectIdentifier(writer)] = RetainedAssetWriterBox(writer: writer)
+        }
+    }
+    func releaseAssetWriter(forKey key: ObjectIdentifier) {
+        withLock { () -> Void in
+            retainedAssetWritersValue.removeValue(forKey: key)
+        }
     }
 }
 
@@ -135,7 +154,7 @@ private final class FinishWritingResumeState: @unchecked Sendable {
 actor CaptureWriter: NSObject {
     typealias AssetWriterFactory = @Sendable (URL, AVFileType) throws -> AVAssetWriter
     public typealias DiagnosticHandler = @Sendable (CaptureWriterDiagnostic) -> Void
-    public static let defaultDeinitFinishWritingTimeoutSeconds: TimeInterval = 5.0
+    public static let defaultFinishWritingTimeoutSeconds: TimeInterval = 5.0
     private static let minimumFinishWritingTimeoutSeconds: TimeInterval = 0.001
 
     private static let defaultAssetWriterFactory: AssetWriterFactory = { url, fileType in
@@ -233,11 +252,16 @@ actor CaptureWriter: NSObject {
             cache.diagnosticHandler = diagnosticHandler
         }
     }
-    /// Bounded wait used by fallback `deinit` cleanup before giving up on `finishWriting`.
-    public var deinitFinishWritingTimeoutSeconds: TimeInterval = CaptureWriter.defaultDeinitFinishWritingTimeoutSeconds {
-        didSet {
-            deinitFinishWritingTimeoutSeconds = max(CaptureWriter.minimumFinishWritingTimeoutSeconds, deinitFinishWritingTimeoutSeconds)
-            cache.deinitFinishWritingTimeoutSeconds = deinitFinishWritingTimeoutSeconds
+    /// Bounded wait used by `finishWriting` before giving up in normal close and fallback `deinit` cleanup paths.
+    private var finishWritingTimeoutSecondsStorage: TimeInterval = CaptureWriter.defaultFinishWritingTimeoutSeconds
+    public var finishWritingTimeoutSeconds: TimeInterval {
+        get {
+            finishWritingTimeoutSecondsStorage
+        }
+        set {
+            let clampedValue = max(CaptureWriter.minimumFinishWritingTimeoutSeconds, newValue)
+            finishWritingTimeoutSecondsStorage = clampedValue
+            cache.finishWritingTimeoutSeconds = clampedValue
         }
     }
     
@@ -292,7 +316,7 @@ actor CaptureWriter: NSObject {
     
     override init() {
         super.init()
-        cache.deinitFinishWritingTimeoutSeconds = deinitFinishWritingTimeoutSeconds
+        cache.finishWritingTimeoutSeconds = finishWritingTimeoutSecondsStorage
         
         // print("Writer.init")
     }
@@ -308,7 +332,7 @@ actor CaptureWriter: NSObject {
     nonisolated internal func testingEmitDeinitDiagnostics(didTimeout: Bool = false) {
         cache.diagnosticHandler?(.deinitWhileRecording)
         if didTimeout {
-            let timeoutSeconds = cache.deinitFinishWritingTimeoutSeconds
+            let timeoutSeconds = cache.finishWritingTimeoutSeconds
             cache.diagnosticHandler?(.finishWritingTimedOut(timeoutSeconds: timeoutSeconds))
         }
     }
@@ -336,7 +360,7 @@ actor CaptureWriter: NSObject {
             let avAssetWriterInputVideo = cache.assetWriterInputVideo
             let avAssetWriterInputAudio = cache.assetWriterInputAudio
             let avAssetWriterInputTimecode = cache.assetWriterInputTimecode
-            let timeoutSeconds = cache.deinitFinishWritingTimeoutSeconds
+            let timeoutSeconds = cache.finishWritingTimeoutSeconds
 
             cache.diagnosticHandler?(.deinitWhileRecording)
             
@@ -523,7 +547,7 @@ actor CaptureWriter: NSObject {
             if duration > 0.0 {
                 avAssetWriter.endSession(atSourceTime: endTime)
             }
-            let timeoutSeconds = deinitFinishWritingTimeoutSeconds
+            let timeoutSeconds = finishWritingTimeoutSeconds
             let didFinish = await waitForFinishWriting(avAssetWriter, timeoutSeconds: timeoutSeconds)
             defer {
                 // unref AVAssetWriter
@@ -558,6 +582,9 @@ actor CaptureWriter: NSObject {
     private func waitForFinishWriting(_ avAssetWriter: AVAssetWriter, timeoutSeconds: TimeInterval) async -> Bool {
         await withCheckedContinuation { continuation in
             let state = FinishWritingResumeState()
+            let cache = self.cache
+            let writerKey = ObjectIdentifier(avAssetWriter)
+            cache.retainAssetWriter(avAssetWriter)
 
             let resume: @Sendable (Bool) -> Void = { value in
                 let shouldResume = state.lock.withLock {
@@ -573,6 +600,7 @@ actor CaptureWriter: NSObject {
             }
 
             avAssetWriter.finishWriting {
+                cache.releaseAssetWriter(forKey: writerKey)
                 resume(true)
             }
 
@@ -1210,7 +1238,7 @@ extension CaptureWriter {
         public var clapVOffset: Int = 0
         public var traceStartupTiming: Bool = false
         public var diagnosticHandler: DiagnosticHandler? = nil
-        public var deinitFinishWritingTimeoutSeconds: TimeInterval = CaptureWriter.defaultDeinitFinishWritingTimeoutSeconds
+        public var finishWritingTimeoutSeconds: TimeInterval = CaptureWriter.defaultFinishWritingTimeoutSeconds
         
         public init() {}
     }
@@ -1252,7 +1280,7 @@ extension CaptureWriter {
         config.clapVOffset = self.clapVOffset
         config.traceStartupTiming = self.traceStartupTiming
         config.diagnosticHandler = self.diagnosticHandler
-        config.deinitFinishWritingTimeoutSeconds = self.deinitFinishWritingTimeoutSeconds
+        config.finishWritingTimeoutSeconds = self.finishWritingTimeoutSeconds
         
         return config
     }
@@ -1288,6 +1316,6 @@ extension CaptureWriter {
         self.clapVOffset = config.clapVOffset
         self.traceStartupTiming = config.traceStartupTiming
         self.diagnosticHandler = config.diagnosticHandler
-        self.deinitFinishWritingTimeoutSeconds = config.deinitFinishWritingTimeoutSeconds
+        self.finishWritingTimeoutSeconds = config.finishWritingTimeoutSeconds
     }
 }

--- a/Sources/DLABCapture/CaptureWriter.swift
+++ b/Sources/DLABCapture/CaptureWriter.swift
@@ -138,18 +138,24 @@ fileprivate final class CaptureWriterCache: @unchecked Sendable {
             retainedAssetWritersValue.removeValue(forKey: key)
         }
     }
-}
-
-private final class AssetWriterBox: @unchecked Sendable {
-    let writer: AVAssetWriter
-    init(writer: AVAssetWriter) {
-        self.writer = writer
+    func cancelWriting(forKey key: ObjectIdentifier) {
+        let writer = withLock {
+            retainedAssetWritersValue[key]?.writer
+        }
+        writer?.cancelWriting()
     }
 }
 
 private final class FinishWritingResumeState: @unchecked Sendable {
     let lock = UnfairLockBox()
     var resumed = false
+}
+
+private final class DispatchWorkItemBox: @unchecked Sendable {
+    let workItem: DispatchWorkItem
+    init(workItem: DispatchWorkItem) {
+        self.workItem = workItem
+    }
 }
 
 /// Movie writer used by `CaptureManager` and other callers that need explicit
@@ -597,7 +603,6 @@ actor CaptureWriter: NSObject {
             let state = FinishWritingResumeState()
             let cache = self.cache
             let writerKey = ObjectIdentifier(avAssetWriter)
-            let writerBox = AssetWriterBox(writer: avAssetWriter)
             cache.retainAssetWriter(avAssetWriter)
 
             let settle: @Sendable (Bool, Bool) -> Void = { didFinish, shouldCancelWriting in
@@ -610,19 +615,22 @@ actor CaptureWriter: NSObject {
                 }
                 if shouldResume {
                     if shouldCancelWriting {
-                        writerBox.writer.cancelWriting()
+                        cache.cancelWriting(forKey: writerKey)
                     }
                     cache.releaseAssetWriter(forKey: writerKey)
                     continuation.resume(returning: didFinish)
                 }
             }
 
-            avAssetWriter.finishWriting {
-                settle(true, false)
-            }
-
-            DispatchQueue.global().asyncAfter(deadline: .now() + timeoutSeconds) {
+            let timeoutWorkItem = DispatchWorkItem {
                 settle(false, true)
+            }
+            let timeoutWorkItemBox = DispatchWorkItemBox(workItem: timeoutWorkItem)
+            DispatchQueue.global().asyncAfter(deadline: .now() + timeoutSeconds, execute: timeoutWorkItem)
+
+            avAssetWriter.finishWriting {
+                timeoutWorkItemBox.workItem.cancel()
+                settle(true, false)
             }
         }
     }

--- a/Sources/DLABCapture/CaptureWriter.swift
+++ b/Sources/DLABCapture/CaptureWriter.swift
@@ -25,6 +25,7 @@ final class UnfairLockBox: @unchecked Sendable {
 enum CaptureWriterError: Swift.Error, LocalizedError {
     case unsupportedMediaType(String)
     case assetWriterIsNotAvailable(String)
+    case finishWritingTimedOut(String)
     case invalidAudioOutputSettings
     case invalidVideoOutputSettings
     case invalidTimecodeOutputSettings
@@ -40,6 +41,8 @@ enum CaptureWriterError: Swift.Error, LocalizedError {
             return "Unsupported media type: \(reason)."
         case .assetWriterIsNotAvailable(let reason):
             return "Invalid AVAssetWriter: \(reason)."
+        case .finishWritingTimedOut(let reason):
+            return "Timed out while finalizing movie file: \(reason)."
         case .invalidAudioOutputSettings:
             return "Invalid audio output settings provided."
         case .invalidVideoOutputSettings:
@@ -62,7 +65,7 @@ enum CaptureWriterError: Swift.Error, LocalizedError {
 
 public enum CaptureWriterDiagnostic: Sendable, Equatable {
     case deinitWhileRecording
-    case deinitFinishWritingTimedOut(timeoutSeconds: Double)
+    case finishWritingTimedOut(timeoutSeconds: Double)
 }
 
 /// Thread safe backing store - works with deinit and nonisolated func.
@@ -116,6 +119,11 @@ fileprivate final class CaptureWriterCache: @unchecked Sendable {
         get { withLock { deinitFinishWritingTimeoutSecondsValue } }
         set { withLock { deinitFinishWritingTimeoutSecondsValue = newValue } }
     }
+}
+
+private final class FinishWritingResumeState: @unchecked Sendable {
+    let lock = UnfairLockBox()
+    var resumed = false
 }
 
 /// Movie writer used by `CaptureManager` and other callers that need explicit
@@ -300,7 +308,7 @@ actor CaptureWriter: NSObject {
         cache.diagnosticHandler?(.deinitWhileRecording)
         if didTimeout {
             let timeoutSeconds = cache.deinitFinishWritingTimeoutSeconds
-            cache.diagnosticHandler?(.deinitFinishWritingTimedOut(timeoutSeconds: timeoutSeconds))
+            cache.diagnosticHandler?(.finishWritingTimedOut(timeoutSeconds: timeoutSeconds))
         }
     }
     
@@ -334,7 +342,7 @@ actor CaptureWriter: NSObject {
             }
             let waitResult = semaphore.wait(timeout: .now() + timeoutSeconds)
             if waitResult == .timedOut {
-                cache.diagnosticHandler?(.deinitFinishWritingTimedOut(timeoutSeconds: timeoutSeconds))
+                cache.diagnosticHandler?(.finishWritingTimedOut(timeoutSeconds: timeoutSeconds))
             }
         }
     }
@@ -507,14 +515,16 @@ actor CaptureWriter: NSObject {
             if duration > 0.0 {
                 avAssetWriter.endSession(atSourceTime: endTime)
             }
-            await withCheckedContinuation { continuation in
-                avAssetWriter.finishWriting {
-                    continuation.resume()
-                }
-            }
+            let timeoutSeconds = deinitFinishWritingTimeoutSeconds
+            let didFinish = await waitForFinishWriting(avAssetWriter, timeoutSeconds: timeoutSeconds)
             defer {
                 // unref AVAssetWriter
                 cleanUp()
+            }
+
+            if didFinish == false {
+                diagnosticHandler?(.finishWritingTimedOut(timeoutSeconds: timeoutSeconds))
+                throw CaptureWriterError.finishWritingTimedOut("AVAssetWriter.finishWriting did not complete within \(timeoutSeconds) seconds.")
             }
             
             // Finalize TS variables and duration
@@ -534,6 +544,35 @@ actor CaptureWriter: NSObject {
         } else {
             let reason = "AVAssetWriter is not available."
             throw CaptureWriterError.assetWriterIsNotAvailable(reason)
+        }
+    }
+
+    private func waitForFinishWriting(_ avAssetWriter: AVAssetWriter, timeoutSeconds: TimeInterval) async -> Bool {
+        await withCheckedContinuation { continuation in
+            let state = FinishWritingResumeState()
+
+            let resume: @Sendable (Bool) -> Void = { value in
+                let shouldResume = state.lock.withLock {
+                    if state.resumed {
+                        return false
+                    }
+                    state.resumed = true
+                    return true
+                }
+                if shouldResume {
+                    continuation.resume(returning: value)
+                }
+            }
+
+            avAssetWriter.finishWriting {
+                resume(true)
+            }
+
+            if timeoutSeconds > 0.0 {
+                DispatchQueue.global().asyncAfter(deadline: .now() + timeoutSeconds) {
+                    resume(false)
+                }
+            }
         }
     }
     

--- a/Sources/DLABCapture/CaptureWriter.swift
+++ b/Sources/DLABCapture/CaptureWriter.swift
@@ -101,12 +101,19 @@ fileprivate final class CaptureWriterCache: @unchecked Sendable {
     }
 }
 
+/// Movie writer used by `CaptureManager` and other callers that need explicit
+/// start/stop control over `AVAssetWriter`.
+///
+/// Callers should await `closeSession()` before releasing the writer.
+/// Cleanup performed from `deinit` is a fallback path only, and it waits for
+/// `finishWriting` for a bounded amount of time before giving up.
 actor CaptureWriter: NSObject {
     typealias AssetWriterFactory = @Sendable (URL, AVFileType) throws -> AVAssetWriter
 
     private static let defaultAssetWriterFactory: AssetWriterFactory = { url, fileType in
         try AVAssetWriter(outputURL: url, fileType: fileType)
     }
+    private static let deinitFinishWritingTimeout: DispatchTimeInterval = .seconds(5)
 
     /* ============================================ */
     // MARK: - readonly property
@@ -259,12 +266,18 @@ actor CaptureWriter: NSObject {
         deinitHelper()
     }
     
-    /// nonisolated deinit helper function - synchronously close the recording session.
+    /// Nonisolated deinit helper function.
+    ///
+    /// This fallback path exists to give `AVAssetWriter.finishWriting` one last
+    /// bounded chance to complete file finalization when the writer is released
+    /// while recording is still active.
     nonisolated private func deinitHelper() {
         if let avAssetWriter = cache.assetWriter, cache.isRecording == true {
             let avAssetWriterInputVideo = cache.assetWriterInputVideo
             let avAssetWriterInputAudio = cache.assetWriterInputAudio
             let avAssetWriterInputTimecode = cache.assetWriterInputTimecode
+
+            NSLog("WARNING: CaptureWriter.deinit invoked while recording is active; attempting bounded finishWriting wait")
             
             avAssetWriterInputVideo?.markAsFinished()
             avAssetWriterInputAudio?.markAsFinished()
@@ -274,7 +287,10 @@ actor CaptureWriter: NSObject {
             avAssetWriter.finishWriting {
                 semaphore.signal()
             }
-            semaphore.wait()
+            let waitResult = semaphore.wait(timeout: .now() + CaptureWriter.deinitFinishWritingTimeout)
+            if waitResult == .timedOut {
+                NSLog("ERROR: Timed out waiting for AVAssetWriter.finishWriting during CaptureWriter.deinit; output file may be incomplete")
+            }
         }
     }
     

--- a/Tests/DLABCaptureTests/DLABCaptureTests.swift
+++ b/Tests/DLABCaptureTests/DLABCaptureTests.swift
@@ -117,44 +117,42 @@ final class DLABCaptureTests: XCTestCase {
         XCTAssertNotNil(appliedConfig.diagnosticHandler)
     }
 
-    func testCaptureWriterConfigRetainsDeinitTimeout() async throws {
+    func testCaptureWriterConfigRetainsFinishWritingTimeout() async throws {
         let writer = CaptureWriter()
         var config = CaptureWriter.CaptureWriterConfig()
 
-        config.deinitFinishWritingTimeoutSeconds = 1.25
+        config.finishWritingTimeoutSeconds = 1.25
         await writer.setConfig(config)
 
         let appliedConfig = await writer.getConfig()
-        XCTAssertEqual(appliedConfig.deinitFinishWritingTimeoutSeconds, 1.25, accuracy: 0.0001)
+        XCTAssertEqual(appliedConfig.finishWritingTimeoutSeconds, 1.25, accuracy: 0.0001)
     }
 
-    func testCaptureWriterConfigClampsZeroDeinitTimeout() async throws {
+    func testCaptureWriterConfigClampsZeroFinishWritingTimeout() async throws {
         let writer = CaptureWriter()
         var config = CaptureWriter.CaptureWriterConfig()
 
-        config.deinitFinishWritingTimeoutSeconds = 0.0
+        config.finishWritingTimeoutSeconds = 0.0
         await writer.setConfig(config)
 
         let appliedConfig = await writer.getConfig()
-        XCTAssertGreaterThan(appliedConfig.deinitFinishWritingTimeoutSeconds, 0.0)
+        XCTAssertGreaterThan(appliedConfig.finishWritingTimeoutSeconds, 0.0)
     }
 
-    func testCaptureWriterDeinitCleanupReportsDiagnostics() {
+    func testCaptureWriterDeinitCleanupReportsDiagnostics() async {
         let startExpectation = expectation(description: "deinit cleanup diagnostic emitted")
         let writer = CaptureWriter()
 
-        Task {
-            var config = CaptureWriter.CaptureWriterConfig()
-            config.deinitFinishWritingTimeoutSeconds = 1.5
-            await writer.setConfig(config)
-            await writer.testingSetDiagnosticHandler { diagnostic in
-                if diagnostic == .deinitWhileRecording {
-                    startExpectation.fulfill()
-                }
+        var config = CaptureWriter.CaptureWriterConfig()
+        config.finishWritingTimeoutSeconds = 1.5
+        await writer.setConfig(config)
+        await writer.testingSetDiagnosticHandler { diagnostic in
+            if diagnostic == .deinitWhileRecording {
+                startExpectation.fulfill()
             }
-            writer.testingInvokeDeinitCleanupWithoutWriter()
         }
+        writer.testingInvokeDeinitCleanupWithoutWriter()
 
-        wait(for: [startExpectation], timeout: 1.0)
+        await fulfillment(of: [startExpectation], timeout: 1.0)
     }
 }

--- a/Tests/DLABCaptureTests/DLABCaptureTests.swift
+++ b/Tests/DLABCaptureTests/DLABCaptureTests.swift
@@ -128,9 +128,19 @@ final class DLABCaptureTests: XCTestCase {
         XCTAssertEqual(appliedConfig.deinitFinishWritingTimeoutSeconds, 1.25, accuracy: 0.0001)
     }
 
+    func testCaptureWriterConfigClampsZeroDeinitTimeout() async throws {
+        let writer = CaptureWriter()
+        var config = CaptureWriter.CaptureWriterConfig()
+
+        config.deinitFinishWritingTimeoutSeconds = 0.0
+        await writer.setConfig(config)
+
+        let appliedConfig = await writer.getConfig()
+        XCTAssertGreaterThan(appliedConfig.deinitFinishWritingTimeoutSeconds, 0.0)
+    }
+
     func testCaptureWriterDeinitCleanupReportsDiagnostics() {
-        let startExpectation = expectation(description: "start diagnostic emitted")
-        let timeoutExpectation = expectation(description: "timeout diagnostic emitted")
+        let startExpectation = expectation(description: "deinit cleanup diagnostic emitted")
         let writer = CaptureWriter()
 
         Task {
@@ -141,13 +151,10 @@ final class DLABCaptureTests: XCTestCase {
                 if diagnostic == .deinitWhileRecording {
                     startExpectation.fulfill()
                 }
-                if diagnostic == .finishWritingTimedOut(timeoutSeconds: 1.5) {
-                    timeoutExpectation.fulfill()
-                }
             }
-            writer.testingEmitDeinitDiagnostics(didTimeout: true)
+            writer.testingInvokeDeinitCleanupWithoutWriter()
         }
 
-        wait(for: [startExpectation, timeoutExpectation], timeout: 1.0)
+        wait(for: [startExpectation], timeout: 1.0)
     }
 }

--- a/Tests/DLABCaptureTests/DLABCaptureTests.swift
+++ b/Tests/DLABCaptureTests/DLABCaptureTests.swift
@@ -113,4 +113,15 @@ final class DLABCaptureTests: XCTestCase {
         let appliedConfig = await writer.getConfig()
         XCTAssertNotNil(appliedConfig.diagnosticHandler)
     }
+
+    func testCaptureWriterConfigRetainsDeinitTimeout() async throws {
+        let writer = CaptureWriter()
+        var config = CaptureWriter.CaptureWriterConfig()
+
+        config.deinitFinishWritingTimeoutSeconds = 1.25
+        await writer.setConfig(config)
+
+        let appliedConfig = await writer.getConfig()
+        XCTAssertEqual(appliedConfig.deinitFinishWritingTimeoutSeconds, 1.25, accuracy: 0.0001)
+    }
 }

--- a/Tests/DLABCaptureTests/DLABCaptureTests.swift
+++ b/Tests/DLABCaptureTests/DLABCaptureTests.swift
@@ -141,7 +141,7 @@ final class DLABCaptureTests: XCTestCase {
                 if diagnostic == .deinitWhileRecording {
                     startExpectation.fulfill()
                 }
-                if diagnostic == .deinitFinishWritingTimedOut(timeoutSeconds: 1.5) {
+                if diagnostic == .finishWritingTimedOut(timeoutSeconds: 1.5) {
                     timeoutExpectation.fulfill()
                 }
             }

--- a/Tests/DLABCaptureTests/DLABCaptureTests.swift
+++ b/Tests/DLABCaptureTests/DLABCaptureTests.swift
@@ -101,4 +101,16 @@ final class DLABCaptureTests: XCTestCase {
         XCTAssertTrue(reason.contains("AVAssetWriter initialization failed"))
         XCTAssertTrue(reason.contains("Injected writer init failure"))
     }
+
+    func testCaptureWriterConfigRetainsDiagnosticHandler() async throws {
+        let writer = CaptureWriter()
+        var config = CaptureWriter.CaptureWriterConfig()
+        let handler: CaptureWriter.DiagnosticHandler = { _ in }
+
+        config.diagnosticHandler = handler
+        await writer.setConfig(config)
+
+        let appliedConfig = await writer.getConfig()
+        XCTAssertNotNil(appliedConfig.diagnosticHandler)
+    }
 }

--- a/Tests/DLABCaptureTests/DLABCaptureTests.swift
+++ b/Tests/DLABCaptureTests/DLABCaptureTests.swift
@@ -44,6 +44,7 @@ final class DLABCaptureTests: XCTestCase {
     func testCaptureManagerTestingWriterConfigReflectsRecordingOptions() throws {
         let manager = CaptureManager()
         let movieURL = FileManager.default.temporaryDirectory.appendingPathComponent("capture-manager-config.mov")
+        let handler: @Sendable (CaptureWriterDiagnostic) -> Void = { _ in }
 
         manager.prefix = "Test-"
         manager.sampleTimescale = 0
@@ -54,6 +55,7 @@ final class DLABCaptureTests: XCTestCase {
         manager.encodeProRes422 = false
         manager.videoStyle = .SD_720_480_16_9
         manager.offset = NSPoint(x: 4, y: -2)
+        manager.captureWriterDiagnosticHandler = handler
 
         let config = manager.testingWriterConfig(movieURL: movieURL, prefix: manager.prefix)
 
@@ -69,6 +71,7 @@ final class DLABCaptureTests: XCTestCase {
         XCTAssertEqual(config.clapHOffset, 4)
         XCTAssertEqual(config.clapVOffset, -2)
         XCTAssertFalse(config.useTimecode)
+        XCTAssertNotNil(config.diagnosticHandler)
         XCTAssertNil(config.sourceVideoFormatDescription)
         XCTAssertNil(config.sourceAudioFormatDescription)
     }
@@ -123,5 +126,28 @@ final class DLABCaptureTests: XCTestCase {
 
         let appliedConfig = await writer.getConfig()
         XCTAssertEqual(appliedConfig.deinitFinishWritingTimeoutSeconds, 1.25, accuracy: 0.0001)
+    }
+
+    func testCaptureWriterDeinitCleanupReportsDiagnostics() {
+        let startExpectation = expectation(description: "start diagnostic emitted")
+        let timeoutExpectation = expectation(description: "timeout diagnostic emitted")
+        let writer = CaptureWriter()
+
+        Task {
+            var config = CaptureWriter.CaptureWriterConfig()
+            config.deinitFinishWritingTimeoutSeconds = 1.5
+            await writer.setConfig(config)
+            await writer.testingSetDiagnosticHandler { diagnostic in
+                if diagnostic == .deinitWhileRecording {
+                    startExpectation.fulfill()
+                }
+                if diagnostic == .deinitFinishWritingTimedOut(timeoutSeconds: 1.5) {
+                    timeoutExpectation.fulfill()
+                }
+            }
+            writer.testingEmitDeinitDiagnostics(didTimeout: true)
+        }
+
+        wait(for: [startExpectation, timeoutExpectation], timeout: 1.0)
     }
 }

--- a/Tests/DLABCaptureTests/DLABCaptureTests.swift
+++ b/Tests/DLABCaptureTests/DLABCaptureTests.swift
@@ -141,6 +141,7 @@ final class DLABCaptureTests: XCTestCase {
 
     func testCaptureWriterDeinitCleanupReportsDiagnostics() async {
         let startExpectation = expectation(description: "deinit cleanup diagnostic emitted")
+        let timeoutExpectation = expectation(description: "deinit timeout diagnostic emitted")
         let writer = CaptureWriter()
 
         var config = CaptureWriter.CaptureWriterConfig()
@@ -150,9 +151,12 @@ final class DLABCaptureTests: XCTestCase {
             if diagnostic == .deinitWhileRecording {
                 startExpectation.fulfill()
             }
+            if diagnostic == .finishWritingTimedOut(timeoutSeconds: 1.5) {
+                timeoutExpectation.fulfill()
+            }
         }
-        writer.testingInvokeDeinitCleanupWithoutWriter()
+        writer.testingInvokeDeinitTimeoutPath()
 
-        await fulfillment(of: [startExpectation], timeout: 1.0)
+        await fulfillment(of: [startExpectation, timeoutExpectation], timeout: 1.0)
     }
 }


### PR DESCRIPTION
## Summary
- bound `CaptureWriter` finalization waits in both `deinit` and normal close paths, and expose injectable diagnostics plus configurable timeout control
- consolidate `CaptureManager` runtime flags behind lock-backed state and pass writer diagnostics through manager config
- add regression coverage for diagnostics propagation, timeout clamping, and writer config round-tripping