### PR TITLE
Add recorded movie range normalization

### DIFF
--- a/Sources/DLABCapture/AudioChannelLayoutHelper.swift
+++ b/Sources/DLABCapture/AudioChannelLayoutHelper.swift
@@ -53,55 +53,55 @@ internal enum AudioChannelLayoutOutputType {
 
 extension CaptureWriter {
     /*
-     NOTE:
-     This function remaps the channel order of the input LPCM Audio SampleBuffer.
-     The framework supposes the native HDMI Audio layout as MPEG_7_1_A (L R C LFE Ls Rs Lc Rc).
-     With Reverse34 enabled, Channel C,LFE order is swapped as LFE,C.
-     Followings shows how channel remapping works from HDMI layout into AAC Layout.
-     
-     ### 3ch Audio
-                     0 1 2 3 4 5 6 7
-     src:MPEG_3_0_A  L R C _ _ _ _ _
-     dst:AAC_3_0
-     dst:MPEG_3_0_B  C L R
-                     2 0 1
-     
-     ### 3ch Audio + Reverse34
-                     0 1 2 3 4 5 6 7
-     src:MPEG_3_0_A  L R _ C _ _ _ _
-     dst:AAC_3_0
-     dst:MPEG_3_0_B  C L R
-                     3 0 1
-     
-     ### 5.1ch Audio
-                     0 1 2 3   4  5  6 7
-     src:MPEG_5_1_A  L R C LFE Ls Rs _ _
-     dst:AAC_5_1
-     dst:MPEG_5_1_D  C L R Ls Rs LFE
-                     2 0 1 4  5  3
-     
-     ### 5.1ch Audio + Reverse34
-                     0 1 2   3 4  5  6 7
-     src:Reverse34   L R LFE C Ls Rs _ _
-     dst:AAC_5_1
-     dst:MPEG_5_1_D  C L R Ls Rs LFE
-                     3 0 1 4  5  2
-     
-     ### 7.1ch Audio
-                     0 1 2 3   4  5  6  7
-     src:MPEG_7_1_A  L R C LFE Ls Rs Lc Rc
-     dst:AAC_7_1
-     dst:MPEG_7_1_B  C Lc Rc L R Ls Rs Lfe
-                     2 6  7  0 1 4  5  3
-     
-     ### 7.1ch Audio + Reverse34
-                     0 1 2   3 4  5  6  7
-     src:Reverse34   L R LFE C Ls Rs Lc Rc
-     dst:AAC_7_1
-     dst:MPEG_7_1_B  C Lc Rc L R Ls Rs Lfe
-                     3 6  7  0 1 4  5  2
+     * NOTE:
+     * This function remaps the channel order of the input LPCM Audio SampleBuffer.
+     * The framework supposes the native HDMI Audio layout as MPEG_7_1_A (L R C LFE Ls Rs Lc Rc).
+     * With Reverse34 enabled, Channel C,LFE order is swapped as LFE,C.
+     * Followings shows how channel remapping works from HDMI layout into AAC Layout.
+     *
+     * ### 3ch Audio
+     *                 0 1 2 3 4 5 6 7
+     * src:MPEG_3_0_A  L R C _ _ _ _ _
+     * dst:AAC_3_0
+     * dst:MPEG_3_0_B  C L R
+     *                 2 0 1
+     *
+     * ### 3ch Audio + Reverse34
+     *                 0 1 2 3 4 5 6 7
+     * src:MPEG_3_0_A  L R _ C _ _ _ _
+     * dst:AAC_3_0
+     * dst:MPEG_3_0_B  C L R
+     *                 3 0 1
+     *
+     * ### 5.1ch Audio
+     *                 0 1 2 3   4  5  6 7
+     * src:MPEG_5_1_A  L R C LFE Ls Rs _ _
+     * dst:AAC_5_1
+     * dst:MPEG_5_1_D  C L R Ls Rs LFE
+     *                 2 0 1 4  5  3
+     *
+     * ### 5.1ch Audio + Reverse34
+     *                 0 1 2   3 4  5  6 7
+     * src:Reverse34   L R LFE C Ls Rs _ _
+     * dst:AAC_5_1
+     * dst:MPEG_5_1_D  C L R Ls Rs LFE
+     *                 3 0 1 4  5  2
+     *
+     * ### 7.1ch Audio
+     *                 0 1 2 3   4  5  6  7
+     * src:MPEG_7_1_A  L R C LFE Ls Rs Lc Rc
+     * dst:AAC_7_1
+     * dst:MPEG_7_1_B  C Lc Rc L R Ls Rs Lfe
+     *                 2 6  7  0 1 4  5  3
+     *
+     * ### 7.1ch Audio + Reverse34
+     *                 0 1 2   3 4  5  6  7
+     * src:Reverse34   L R LFE C Ls Rs Lc Rc
+     * dst:AAC_7_1
+     * dst:MPEG_7_1_B  C Lc Rc L R Ls Rs Lfe
+     *                 3 6  7  0 1 4  5  2
      */
-
+    
     /// Check if the AudioChannelLayout has Reverse34 layout.
     /// - Parameters:
     ///  - layoutPtr: Pointer to the AudioChannelLayout structure.
@@ -154,7 +154,7 @@ extension CaptureWriter {
         let layout = layoutPtr.pointee
         let tag = layout.mChannelLayoutTag
         let numDescriptions = Int(layout.mNumberChannelDescriptions)
-
+        
         // Count valid channels based on mChannelBitmap
         if tag == kAudioChannelLayoutTag_UseChannelBitmap {
             let bitmap: UInt32 = layout.mChannelBitmap.rawValue
@@ -185,7 +185,7 @@ extension CaptureWriter {
     /* ============================================ */
     // MARK: - Remap LPCM Channel Order for AAC Encoding
     /* ============================================ */
-
+    
     /// Remap the channel order of an LPCM Audio SampleBuffer for AAC encoding (3ch, 5.1ch, 7.1ch).
     /// - Parameters:
     ///   - inSampleBuffer: The input CMSampleBuffer containing LPCM audio data.
@@ -580,7 +580,7 @@ extension CaptureWriter {
             .advanced(by: descOffset)
             .bindMemory(to: AudioChannelDescription.self, capacity: descCount)
     }
-
+    
     /// Get pointer to the channel descriptions array in the output AudioChannelLayout
     /// - Parameter layoutPtr: Pointer to the AudioChannelLayout structure
     /// - Returns: Pointer to the channel descriptions array, or nil if unable to access

--- a/Sources/DLABCapture/AudioChannelLayoutHelper.swift
+++ b/Sources/DLABCapture/AudioChannelLayoutHelper.swift
@@ -57,7 +57,7 @@ extension CaptureWriter {
      * This function remaps the channel order of the input LPCM Audio SampleBuffer.
      * The framework supposes the native HDMI Audio layout as MPEG_7_1_A (L R C LFE Ls Rs Lc Rc).
      * With Reverse34 enabled, Channel C,LFE order is swapped as LFE,C.
-     * Followings shows how channel remapping works from HDMI layout into AAC Layout.
+     * The following shows how channel remapping works from HDMI layout into AAC Layout.
      *
      * ### 3ch Audio
      *                 0 1 2 3 4 5 6 7

--- a/Sources/DLABCapture/CaptureManager+Util.swift
+++ b/Sources/DLABCapture/CaptureManager+Util.swift
@@ -77,6 +77,11 @@ extension CaptureManager {
         return info
     }
     
+    @discardableResult
+    public func normalizeRecordedMovieTimeRange(at movieURL: URL) throws -> Bool {
+        try RecordedMovieTimeRangeNormalizer.normalizeMovie(at: movieURL).didRewrite
+    }
+    
     /// Dictionary of AudioSettingInfo
     /// - Parameter setting: DLABAudioSetting
     /// - Returns: Dictionary

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -600,9 +600,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                     
                     let writerError = await writer.internalError
                     let outputURL = await writer.resolvedMovieURL()
-                    if shouldPostProcessRecordedMovie(writerError: writerError, outputURL: outputURL) {
-                        await postProcessRecordedMovieIfNeeded(at: outputURL!)
-                    }
+                    await handleRecordedMoviePostProcess(writerError: writerError, outputURL: outputURL)
                 }
                 
                 writerPrepared = (writer != nil)
@@ -844,7 +842,11 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     internal func testingShouldPostProcessRecordedMovie(writerError: Error?, outputURL: URL?) -> Bool {
         shouldPostProcessRecordedMovie(writerError: writerError, outputURL: outputURL)
     }
-    
+
+    internal func testingHandleRecordedMoviePostProcess(writerError: Error?, outputURL: URL?) async {
+        await handleRecordedMoviePostProcess(writerError: writerError, outputURL: outputURL)
+    }
+
     internal func testingPostProcessRecordedMovieIfNeeded(at movieURL: URL) async {
         await postProcessRecordedMovieIfNeeded(at: movieURL)
     }
@@ -898,6 +900,17 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         }
         
         return true
+    }
+
+    private func handleRecordedMoviePostProcess(writerError: Error?, outputURL: URL?) async {
+        lastRecordedMoviePostProcessError = nil
+
+        guard let outputURL,
+              shouldPostProcessRecordedMovie(writerError: writerError, outputURL: outputURL) else {
+            return
+        }
+
+        await postProcessRecordedMovieIfNeeded(at: outputURL)
     }
     
     private func postProcessRecordedMovieIfNeeded(at movieURL: URL) async {

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -69,8 +69,9 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         var writerPrepared: Bool = false
         var timecodeReady: Bool = false
         var lastDuration: Float64 = 0.0
+        var lastRecordedMoviePostProcessError: Error? = nil
     }
-
+    
     /// Verbose mode (debugging purpose)
     public var verbose: Bool = false
     
@@ -80,31 +81,31 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     
     private let stateLock = UnfairLockBox()
     private var runtimeState = CaptureRuntimeState()
-
+    
     private func withRuntimeState<T>(_ body: (inout CaptureRuntimeState) -> T) -> T {
         stateLock.withLock {
             body(&runtimeState)
         }
     }
-
+    
     private func runtimeStateValue<T>(_ keyPath: KeyPath<CaptureRuntimeState, T>) -> T {
         stateLock.withLock {
             runtimeState[keyPath: keyPath]
         }
     }
-
+    
     private func setRunning(_ newValue: Bool) {
         withRuntimeState { $0.running = newValue }
     }
-
+    
     private func setRecording(_ newValue: Bool) {
         withRuntimeState { $0.recording = newValue }
     }
-
+    
     private func setTimecodeReady(_ newValue: Bool) {
         withRuntimeState { $0.timecodeReady = newValue }
     }
-
+    
     /// True while capture is running
     public var running: Bool {
         runtimeStateValue(\.running)
@@ -238,7 +239,15 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     
     /// Optional. Set preferred output URL.
     public var movieURL: URL? = nil
-
+    
+    /// Optional post-save movie range normalization.
+    public var trimsRecordedMovieTimeRangeAfterRecording: Bool = false
+    public var recordedMoviePostProcessErrorHandler: (@Sendable (URL, Error) -> Void)? = nil
+    public private(set) var lastRecordedMoviePostProcessError: Error? {
+        get { runtimeStateValue(\.lastRecordedMoviePostProcessError) }
+        set { withRuntimeState { $0.lastRecordedMoviePostProcessError = newValue } }
+    }
+    
     /// Optional callback for non-fatal `CaptureWriter` diagnostics during fallback cleanup.
     public var captureWriterDiagnosticHandler: (@Sendable (CaptureWriterDiagnostic) -> Void)? = nil
     
@@ -588,6 +597,12 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                     await writer.closeSession()
                     // keep last duration
                     lastDuration = await writer.duration
+                    
+                    let writerError = await writer.internalError
+                    let outputURL = await writer.resolvedMovieURL()
+                    if shouldPostProcessRecordedMovie(writerError: writerError, outputURL: outputURL) {
+                        await postProcessRecordedMovieIfNeeded(at: outputURL!)
+                    }
                 }
                 
                 writerPrepared = (writer != nil)
@@ -821,9 +836,17 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         
         return config
     }
-
+    
     internal func testingWriterConfig(movieURL: URL?, prefix: String?) -> CaptureWriter.CaptureWriterConfig {
         makeWriterConfig(movieURL: movieURL, prefix: prefix)
+    }
+    
+    internal func testingShouldPostProcessRecordedMovie(writerError: Error?, outputURL: URL?) -> Bool {
+        shouldPostProcessRecordedMovie(writerError: writerError, outputURL: outputURL)
+    }
+    
+    internal func testingPostProcessRecordedMovieIfNeeded(at movieURL: URL) async {
+        await postProcessRecordedMovieIfNeeded(at: movieURL)
     }
     
     private func prepTimecodeHelper() {
@@ -862,6 +885,30 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         if self.verbose {
             let output = message.joined(separator: "\n")
             print(output)
+        }
+    }
+    
+    private func shouldPostProcessRecordedMovie(writerError: Error?, outputURL: URL?) -> Bool {
+        guard trimsRecordedMovieTimeRangeAfterRecording,
+              writerError == nil,
+              let outputURL,
+              outputURL.isFileURL,
+              FileManager.default.fileExists(atPath: outputURL.path) else {
+            return false
+        }
+        
+        return true
+    }
+    
+    private func postProcessRecordedMovieIfNeeded(at movieURL: URL) async {
+        lastRecordedMoviePostProcessError = nil
+        
+        do {
+            _ = try normalizeRecordedMovieTimeRange(at: movieURL)
+        } catch {
+            lastRecordedMoviePostProcessError = error
+            recordedMoviePostProcessErrorHandler?(movieURL, error)
+            printVerbose("ERROR:CaptureManager.postProcessRecordedMovieIfNeeded - \(error.localizedDescription)")
         }
     }
     

--- a/Sources/DLABCapture/CaptureWriter.swift
+++ b/Sources/DLABCapture/CaptureWriter.swift
@@ -76,7 +76,7 @@ fileprivate final class CaptureWriterCache: @unchecked Sendable {
             self.writer = writer
         }
     }
-
+    
     private let lock = UnfairLockBox()
     private func withLock<T>(_ block: () -> T) -> T {
         lock.withLock(block)
@@ -114,19 +114,19 @@ fileprivate final class CaptureWriterCache: @unchecked Sendable {
         get { withLock { avAssetWriterInputTimecodeValue } }
         set { withLock { avAssetWriterInputTimecodeValue = newValue } }
     }
-
+    
     private var diagnosticHandlerValue: (@Sendable (CaptureWriterDiagnostic) -> Void)? = nil
     var diagnosticHandler: (@Sendable (CaptureWriterDiagnostic) -> Void)? {
         get { withLock { diagnosticHandlerValue } }
         set { withLock { diagnosticHandlerValue = newValue } }
     }
-
+    
     private var finishWritingTimeoutSecondsValue: TimeInterval = CaptureWriter.defaultFinishWritingTimeoutSeconds
     var finishWritingTimeoutSeconds: TimeInterval {
         get { withLock { finishWritingTimeoutSecondsValue } }
         set { withLock { finishWritingTimeoutSecondsValue = newValue } }
     }
-
+    
     private var retainedAssetWritersValue: [ObjectIdentifier: RetainedAssetWriterBox] = [:]
     func retainAssetWriter(_ writer: AVAssetWriter) {
         withLock { () -> Void in
@@ -169,11 +169,11 @@ actor CaptureWriter: NSObject {
     public typealias DiagnosticHandler = @Sendable (CaptureWriterDiagnostic) -> Void
     public static let defaultFinishWritingTimeoutSeconds: TimeInterval = 5.0
     private static let minimumFinishWritingTimeoutSeconds: TimeInterval = 0.001
-
+    
     private static let defaultAssetWriterFactory: AssetWriterFactory = { url, fileType in
         try AVAssetWriter(outputURL: url, fileType: fileType)
     }
-
+    
     /* ============================================ */
     // MARK: - readonly property
     /* ============================================ */
@@ -334,15 +334,15 @@ actor CaptureWriter: NSObject {
         
         // print("Writer.init")
     }
-
+    
     internal func testingSetAssetWriterFactory(_ factory: AssetWriterFactory?) {
         assetWriterFactory = factory ?? CaptureWriter.defaultAssetWriterFactory
     }
-
+    
     internal func testingSetDiagnosticHandler(_ handler: DiagnosticHandler?) {
         diagnosticHandler = handler
     }
-
+    
     nonisolated internal func testingEmitDeinitDiagnostics(didTimeout: Bool = false) {
         cache.diagnosticHandler?(.deinitWhileRecording)
         if didTimeout {
@@ -350,7 +350,7 @@ actor CaptureWriter: NSObject {
             cache.diagnosticHandler?(.finishWritingTimedOut(timeoutSeconds: timeoutSeconds))
         }
     }
-
+    
     nonisolated internal func testingInvokeDeinitTimeoutPath() {
         let timeoutSeconds = cache.finishWritingTimeoutSeconds
         cache.diagnosticHandler?(.deinitWhileRecording)
@@ -376,7 +376,7 @@ actor CaptureWriter: NSObject {
             let avAssetWriterInputTimecode = cache.assetWriterInputTimecode
             let timeoutSeconds = cache.finishWritingTimeoutSeconds
             let writerKey = ObjectIdentifier(avAssetWriter)
-
+            
             cache.diagnosticHandler?(.deinitWhileRecording)
             cache.retainAssetWriter(avAssetWriter)
             
@@ -462,6 +462,10 @@ actor CaptureWriter: NSObject {
             let reason = "No recording session is in progress."
             internalError = CaptureWriterError.assetWriterIsNotAvailable(reason)
         }
+    }
+    
+    public func resolvedMovieURL() -> URL? {
+        movieURL
     }
     
     /// Append SampleBuffer with UnsafeSampleBufferWrapper
@@ -572,7 +576,7 @@ actor CaptureWriter: NSObject {
                 // unref AVAssetWriter
                 cleanUp()
             }
-
+            
             if didFinish == false {
                 diagnosticHandler?(.finishWritingTimedOut(timeoutSeconds: timeoutSeconds))
                 throw CaptureWriterError.finishWritingTimedOut("AVAssetWriter.finishWriting did not complete within \(timeoutSeconds) seconds")
@@ -597,14 +601,14 @@ actor CaptureWriter: NSObject {
             throw CaptureWriterError.assetWriterIsNotAvailable(reason)
         }
     }
-
+    
     private func waitForFinishWriting(_ avAssetWriter: AVAssetWriter, timeoutSeconds: TimeInterval) async -> Bool {
         await withCheckedContinuation { continuation in
             let state = FinishWritingResumeState()
             let cache = self.cache
             let writerKey = ObjectIdentifier(avAssetWriter)
             cache.retainAssetWriter(avAssetWriter)
-
+            
             let settle: @Sendable (Bool, Bool) -> Void = { didFinish, shouldCancelWriting in
                 let shouldResume = state.lock.withLock {
                     if state.resumed {
@@ -621,13 +625,13 @@ actor CaptureWriter: NSObject {
                     continuation.resume(returning: didFinish)
                 }
             }
-
+            
             let timeoutWorkItem = DispatchWorkItem {
                 settle(false, true)
             }
             let timeoutWorkItemBox = DispatchWorkItemBox(workItem: timeoutWorkItem)
             DispatchQueue.global().asyncAfter(deadline: .now() + timeoutSeconds, execute: timeoutWorkItem)
-
+            
             avAssetWriter.finishWriting {
                 timeoutWorkItemBox.workItem.cancel()
                 settle(true, false)
@@ -1074,7 +1078,7 @@ actor CaptureWriter: NSObject {
                 //
                 audioOutputSettings[AVChannelLayoutKey] = aclData
             }
-
+            
             // print("Channel count AVAF:\(avafChannelCount ?? 0), ACL:\(aclChannelCount ?? 0)")
         }
         
@@ -1159,7 +1163,7 @@ actor CaptureWriter: NSObject {
                         mNumberChannelDescriptions: 0,
                         mChannelDescriptions: AudioChannelDescription()
                     )
-
+                    
                     let layoutData = withUnsafePointer(to: &outLayout) { layoutPtr in
                         return NSData(bytes: layoutPtr, length: MemoryLayout<AudioChannelLayout>.size)
                     }

--- a/Sources/DLABCapture/RecordedMovieTimeRangeNormalizer.swift
+++ b/Sources/DLABCapture/RecordedMovieTimeRangeNormalizer.swift
@@ -1,0 +1,238 @@
+//
+//  RecordedMovieTimeRangeNormalizer.swift
+//  DLABCapture
+//
+//  Created by GitHub Copilot on 2026/05/05.
+//
+
+import Foundation
+import AVFoundation
+import UniformTypeIdentifiers
+
+internal enum RecordedMovieReferenceMediaKind: String, Sendable {
+    case video
+    case audio
+    
+    var mediaCharacteristic: AVMediaCharacteristic {
+        switch self {
+        case .video:
+            return .visual
+        case .audio:
+            return .audible
+        }
+    }
+}
+
+internal struct RecordedMovieNormalizationResult: Sendable {
+    let didRewrite: Bool
+    let mediaKind: RecordedMovieReferenceMediaKind
+    let selectedRange: CMTimeRange
+}
+
+internal enum RecordedMovieTimeRangeNormalizationError: Error, LocalizedError {
+    case unsupportedMovieFileType(String)
+    case movieOpenFailed(String)
+    case movieDurationUnavailable
+    case noEligibleVideoOrAudioTrack
+    case selectedRangeUnavailable(RecordedMovieReferenceMediaKind)
+    case destinationMoviePreparationFailed(String)
+    case movieRangeInsertFailed(String)
+    case movieHeaderWriteFailed(String)
+    
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedMovieFileType(let reason):
+            return "Unsupported movie file type: \(reason)."
+        case .movieOpenFailed(let reason):
+            return "Failed to open movie: \(reason)."
+        case .movieDurationUnavailable:
+            return "Movie duration is unavailable."
+        case .noEligibleVideoOrAudioTrack:
+            return "No eligible video or audio track was found."
+        case .selectedRangeUnavailable(let mediaKind):
+            return "Selected \(mediaKind.rawValue) range is unavailable."
+        case .destinationMoviePreparationFailed(let reason):
+            return "Failed to prepare destination movie: \(reason)."
+        case .movieRangeInsertFailed(let reason):
+            return "Failed to insert movie range: \(reason)."
+        case .movieHeaderWriteFailed(let reason):
+            return "Failed to write movie header: \(reason)."
+        }
+    }
+}
+
+internal enum RecordedMovieTimeRangeNormalizer {
+    @discardableResult
+    static func normalizeMovie(at movieURL: URL) throws -> RecordedMovieNormalizationResult {
+        try validateMovieFileType(at: movieURL)
+        let sourceMovie = try openSourceMovie(at: movieURL)
+        let (mediaKind, selectedRange) = try chooseReferenceRange(in: sourceMovie)
+        let movieRange = try moviePresentationRange(for: sourceMovie)
+        let selectedEnd = CMTimeRangeGetEnd(selectedRange)
+        let movieEnd = CMTimeRangeGetEnd(movieRange)
+        
+        let needsLeadingTrim = CMTimeCompare(selectedRange.start, movieRange.start) > 0
+        let needsTrailingTrim = CMTimeCompare(selectedEnd, movieEnd) < 0
+        guard needsLeadingTrim || needsTrailingTrim else {
+            return RecordedMovieNormalizationResult(
+                didRewrite: false,
+                mediaKind: mediaKind,
+                selectedRange: selectedRange
+            )
+        }
+        
+        let trimmedMovie = try buildTrimmedMovie(from: sourceMovie, selectedRange: selectedRange)
+        try commit(movie: trimmedMovie, to: movieURL)
+        
+        return RecordedMovieNormalizationResult(
+            didRewrite: true,
+            mediaKind: mediaKind,
+            selectedRange: selectedRange
+        )
+    }
+    
+    private static func validateMovieFileType(at movieURL: URL) throws {
+        guard movieURL.isFileURL else {
+            throw RecordedMovieTimeRangeNormalizationError.movieOpenFailed("URL is not a file URL: \(movieURL.absoluteString)")
+        }
+        
+        let resourceKeys: Set<URLResourceKey> = [.isRegularFileKey, .contentTypeKey, .typeIdentifierKey]
+        let resourceValues: URLResourceValues
+        do {
+            resourceValues = try movieURL.resourceValues(forKeys: resourceKeys)
+        } catch {
+            throw RecordedMovieTimeRangeNormalizationError.movieOpenFailed("\(movieURL.path): \(error.localizedDescription)")
+        }
+        
+        guard resourceValues.isRegularFile != false else {
+            throw RecordedMovieTimeRangeNormalizationError.movieOpenFailed("Path is not a regular file: \(movieURL.path)")
+        }
+        
+        if let contentType = resourceValues.contentType {
+            guard contentType == .quickTimeMovie || contentType.conforms(to: .quickTimeMovie) else {
+                throw RecordedMovieTimeRangeNormalizationError.unsupportedMovieFileType("\(movieURL.path) (\(contentType.identifier))")
+            }
+            return
+        }
+        
+        if let typeIdentifier = resourceValues.typeIdentifier, typeIdentifier == AVFileType.mov.rawValue {
+            return
+        }
+        
+        throw RecordedMovieTimeRangeNormalizationError.unsupportedMovieFileType(movieURL.path)
+    }
+    
+    private static func openSourceMovie(at movieURL: URL) throws -> AVMutableMovie {
+        let movie = AVMutableMovie(url: movieURL, options: nil)
+        
+        let duration = movie.duration
+        guard duration.isValid, !duration.isIndefinite else {
+            throw RecordedMovieTimeRangeNormalizationError.movieDurationUnavailable
+        }
+        
+        return movie
+    }
+    
+    private static func nonEmptyPresentationUnion(for track: AVMutableMovieTrack) -> CMTimeRange? {
+        var unionRange: CMTimeRange? = nil
+        
+        for segment in track.segments where !segment.isEmpty {
+            let segmentRange = segment.timeMapping.target
+            guard segmentRange.isValid, !segmentRange.isEmpty else { continue }
+            
+            if let current = unionRange {
+                unionRange = CMTimeRangeGetUnion(current, otherRange: segmentRange)
+            } else {
+                unionRange = segmentRange
+            }
+        }
+        
+        guard let unionRange, unionRange.isValid, !unionRange.isEmpty else {
+            return nil
+        }
+        
+        return unionRange
+    }
+    
+    private static func aggregatePresentationUnion(in movie: AVMutableMovie,
+                                                   characteristic: AVMediaCharacteristic) -> CMTimeRange? {
+        var unionRange: CMTimeRange? = nil
+        
+        for track in movie.tracks(withMediaCharacteristic: characteristic) {
+            guard let trackRange = nonEmptyPresentationUnion(for: track) else { continue }
+            if let current = unionRange {
+                unionRange = CMTimeRangeGetUnion(current, otherRange: trackRange)
+            } else {
+                unionRange = trackRange
+            }
+        }
+        
+        guard let unionRange, unionRange.isValid, !unionRange.isEmpty else {
+            return nil
+        }
+        
+        return unionRange
+    }
+    
+    private static func chooseReferenceRange(in movie: AVMutableMovie) throws -> (RecordedMovieReferenceMediaKind, CMTimeRange) {
+        if let videoRange = aggregatePresentationUnion(in: movie, characteristic: .visual) {
+            return try validatedSelection(videoRange, mediaKind: .video)
+        }
+        
+        if let audioRange = aggregatePresentationUnion(in: movie, characteristic: .audible) {
+            return try validatedSelection(audioRange, mediaKind: .audio)
+        }
+        
+        throw RecordedMovieTimeRangeNormalizationError.noEligibleVideoOrAudioTrack
+    }
+    
+    private static func validatedSelection(_ range: CMTimeRange,
+                                           mediaKind: RecordedMovieReferenceMediaKind) throws -> (RecordedMovieReferenceMediaKind, CMTimeRange) {
+        guard range.isValid, !range.isEmpty else {
+            throw RecordedMovieTimeRangeNormalizationError.selectedRangeUnavailable(mediaKind)
+        }
+        return (mediaKind, range)
+    }
+    
+    private static func moviePresentationRange(for movie: AVMutableMovie) throws -> CMTimeRange {
+        let duration = movie.duration
+        guard duration.isValid, !duration.isIndefinite else {
+            throw RecordedMovieTimeRangeNormalizationError.movieDurationUnavailable
+        }
+        
+        let range = CMTimeRange(start: .zero, duration: duration)
+        guard range.isValid else {
+            throw RecordedMovieTimeRangeNormalizationError.movieDurationUnavailable
+        }
+        
+        return range
+    }
+    
+    private static func buildTrimmedMovie(from sourceMovie: AVMutableMovie,
+                                          selectedRange: CMTimeRange) throws -> AVMutableMovie {
+        let destinationMovie: AVMutableMovie
+        do {
+            destinationMovie = try AVMutableMovie(settingsFrom: sourceMovie, options: nil)
+        } catch {
+            throw RecordedMovieTimeRangeNormalizationError.destinationMoviePreparationFailed(error.localizedDescription)
+        }
+        
+        do {
+            try destinationMovie.insertTimeRange(selectedRange, of: sourceMovie, at: .zero, copySampleData: false)
+        } catch {
+            throw RecordedMovieTimeRangeNormalizationError.movieRangeInsertFailed(error.localizedDescription)
+        }
+        
+        return destinationMovie
+    }
+    
+    private static func commit(movie: AVMutableMovie, to originalURL: URL) throws {
+        do {
+            try movie.writeHeader(to: originalURL,
+                                  fileType: .mov,
+                                  options: .addMovieHeaderToDestination)
+        } catch {
+            throw RecordedMovieTimeRangeNormalizationError.movieHeaderWriteFailed("\(originalURL.path): \(error.localizedDescription)")
+        }
+    }
+}

--- a/Sources/DLABCapture/RecordedMovieTimeRangeNormalizer.swift
+++ b/Sources/DLABCapture/RecordedMovieTimeRangeNormalizer.swift
@@ -228,41 +228,12 @@ internal enum RecordedMovieTimeRangeNormalizer {
     }
     
     private static func commit(movie: AVMutableMovie, to originalURL: URL) throws {
-        let fileManager = FileManager.default
-        let temporaryFilename = "\(originalURL.deletingPathExtension().lastPathComponent)-normalize-\(UUID().uuidString).mov"
-        let temporaryURL = originalURL
-            .deletingLastPathComponent()
-            .appendingPathComponent(temporaryFilename)
-
         do {
-            try fileManager.copyItem(at: originalURL, to: temporaryURL)
-        } catch {
-            throw RecordedMovieTimeRangeNormalizationError.movieHeaderWriteFailed("Failed to prepare temporary movie file for \(originalURL.path): \(error.localizedDescription)")
-        }
-
-        var shouldCleanupTemp = true
-        defer {
-            if shouldCleanupTemp {
-                try? fileManager.removeItem(at: temporaryURL)
-            }
-        }
-
-        do {
-            try movie.writeHeader(to: temporaryURL,
+            try movie.writeHeader(to: originalURL,
                                   fileType: .mov,
                                   options: .addMovieHeaderToDestination)
         } catch {
             throw RecordedMovieTimeRangeNormalizationError.movieHeaderWriteFailed("\(originalURL.path): \(error.localizedDescription)")
-        }
-
-        do {
-            _ = try fileManager.replaceItemAt(originalURL,
-                                              withItemAt: temporaryURL,
-                                              backupItemName: nil,
-                                              options: [])
-            shouldCleanupTemp = false
-        } catch {
-            throw RecordedMovieTimeRangeNormalizationError.movieHeaderWriteFailed("Failed to replace \(originalURL.path) with normalized movie header: \(error.localizedDescription)")
         }
     }
 }

--- a/Sources/DLABCapture/RecordedMovieTimeRangeNormalizer.swift
+++ b/Sources/DLABCapture/RecordedMovieTimeRangeNormalizer.swift
@@ -2,7 +2,8 @@
 //  RecordedMovieTimeRangeNormalizer.swift
 //  DLABCapture
 //
-//  Created by GitHub Copilot on 2026/05/05.
+//  Created by Takashi Mochizuki on 2026/05/05.
+//  Copyright © 2026 MyCometG3. All rights reserved.
 //
 
 import Foundation
@@ -104,7 +105,7 @@ internal enum RecordedMovieTimeRangeNormalizer {
             throw RecordedMovieTimeRangeNormalizationError.movieOpenFailed("\(movieURL.path): \(error.localizedDescription)")
         }
         
-        guard resourceValues.isRegularFile != false else {
+        guard resourceValues.isRegularFile == true else {
             throw RecordedMovieTimeRangeNormalizationError.movieOpenFailed("Path is not a regular file: \(movieURL.path)")
         }
         
@@ -227,12 +228,41 @@ internal enum RecordedMovieTimeRangeNormalizer {
     }
     
     private static func commit(movie: AVMutableMovie, to originalURL: URL) throws {
+        let fileManager = FileManager.default
+        let temporaryFilename = "\(originalURL.deletingPathExtension().lastPathComponent)-normalize-\(UUID().uuidString).mov"
+        let temporaryURL = originalURL
+            .deletingLastPathComponent()
+            .appendingPathComponent(temporaryFilename)
+
         do {
-            try movie.writeHeader(to: originalURL,
+            try fileManager.copyItem(at: originalURL, to: temporaryURL)
+        } catch {
+            throw RecordedMovieTimeRangeNormalizationError.movieHeaderWriteFailed("Failed to prepare temporary movie file for \(originalURL.path): \(error.localizedDescription)")
+        }
+
+        var shouldCleanupTemp = true
+        defer {
+            if shouldCleanupTemp {
+                try? fileManager.removeItem(at: temporaryURL)
+            }
+        }
+
+        do {
+            try movie.writeHeader(to: temporaryURL,
                                   fileType: .mov,
                                   options: .addMovieHeaderToDestination)
         } catch {
             throw RecordedMovieTimeRangeNormalizationError.movieHeaderWriteFailed("\(originalURL.path): \(error.localizedDescription)")
+        }
+
+        do {
+            _ = try fileManager.replaceItemAt(originalURL,
+                                              withItemAt: temporaryURL,
+                                              backupItemName: nil,
+                                              options: [])
+            shouldCleanupTemp = false
+        } catch {
+            throw RecordedMovieTimeRangeNormalizationError.movieHeaderWriteFailed("Failed to replace \(originalURL.path) with normalized movie header: \(error.localizedDescription)")
         }
     }
 }

--- a/Tests/DLABCaptureTests/RecordedMovieTimeRangeNormalizerTests.swift
+++ b/Tests/DLABCaptureTests/RecordedMovieTimeRangeNormalizerTests.swift
@@ -1,0 +1,510 @@
+import XCTest
+import AVFoundation
+import AudioToolbox
+import CoreVideo
+@testable import DLABCapture
+
+final class RecordedMovieTimeRangeNormalizerTests: XCTestCase {
+    func testNormalizerTrimsLeadingVideoPadding() async throws {
+        let movieURL = try await TestMovieFactory.makeMovie(
+            name: "leading-video-padding",
+            videoDuration: TestMovieFactory.videoSpan,
+            audioDuration: nil
+        )
+        defer { TestMovieFactory.cleanup(movieURL) }
+
+        try TestMovieFactory.mutateMovie(at: movieURL) { movie in
+            movie.timescale = 600
+            movie.insertEmptyTimeRange(CMTimeRange(start: .zero, duration: TestMovieFactory.leadingPad))
+        }
+
+        let result = try RecordedMovieTimeRangeNormalizer.normalizeMovie(at: movieURL)
+        XCTAssertTrue(result.didRewrite)
+        XCTAssertEqual(result.mediaKind, .video)
+
+        let movie = try TestMovieFactory.openMovie(at: movieURL)
+        XCTAssertEqual(movie.duration.seconds, TestMovieFactory.videoSpan.seconds, accuracy: 0.001)
+
+        let ranges = try TestMovieFactory.trackPresentationRanges(in: movie, characteristic: .visual)
+        XCTAssertEqual(ranges.count, 1)
+        XCTAssertEqual(ranges[0].start.seconds, 0.0, accuracy: 0.001)
+        XCTAssertEqual(CMTimeRangeGetEnd(ranges[0]).seconds, TestMovieFactory.videoSpan.seconds, accuracy: 0.001)
+    }
+
+    func testCaptureManagerNormalizeRecordedMovieTimeRangeTrimsTrailingAudioOverrunAgainstVideo() async throws {
+        let movieURL = try await TestMovieFactory.makeMovie(
+            name: "trailing-audio-overrun",
+            videoDuration: TestMovieFactory.videoSpan,
+            audioDuration: TestMovieFactory.longerAudioSpan
+        )
+        defer { TestMovieFactory.cleanup(movieURL) }
+
+        let manager = CaptureManager()
+        let rewritten = try manager.normalizeRecordedMovieTimeRange(at: movieURL)
+        XCTAssertTrue(rewritten)
+
+        let movie = try TestMovieFactory.openMovie(at: movieURL)
+        XCTAssertEqual(movie.duration.seconds, TestMovieFactory.videoSpan.seconds, accuracy: 0.001)
+    }
+
+    func testNormalizerUsesAudioFallbackForAudioOnlyMovie() async throws {
+        let movieURL = try await TestMovieFactory.makeMovie(
+            name: "audio-only-fallback",
+            videoDuration: nil,
+            audioDuration: TestMovieFactory.audioOnlySpan
+        )
+        defer { TestMovieFactory.cleanup(movieURL) }
+
+        try TestMovieFactory.mutateMovie(at: movieURL) { movie in
+            movie.timescale = 600
+            movie.insertEmptyTimeRange(CMTimeRange(start: .zero, duration: TestMovieFactory.leadingPad))
+        }
+
+        let result = try RecordedMovieTimeRangeNormalizer.normalizeMovie(at: movieURL)
+        XCTAssertTrue(result.didRewrite)
+        XCTAssertEqual(result.mediaKind, .audio)
+
+        let movie = try TestMovieFactory.openMovie(at: movieURL)
+        XCTAssertEqual(movie.duration.seconds, TestMovieFactory.audioOnlySpan.seconds, accuracy: 0.001)
+
+        let ranges = try TestMovieFactory.trackPresentationRanges(in: movie, characteristic: .audible)
+        XCTAssertEqual(ranges.count, 1)
+        XCTAssertEqual(ranges[0].start.seconds, 0.0, accuracy: 0.001)
+    }
+
+    func testNormalizerReturnsFalseWhenMovieIsAlreadyAligned() async throws {
+        let movieURL = try await TestMovieFactory.makeMovie(
+            name: "already-aligned",
+            videoDuration: TestMovieFactory.videoSpan,
+            audioDuration: nil
+        )
+        defer { TestMovieFactory.cleanup(movieURL) }
+
+        let result = try RecordedMovieTimeRangeNormalizer.normalizeMovie(at: movieURL)
+        XCTAssertFalse(result.didRewrite)
+        XCTAssertEqual(result.mediaKind, .video)
+    }
+
+    func testNormalizerUsesEarliestStartLatestEndAcrossOverlappingVideoTracks() async throws {
+        let movieURL = try await TestMovieFactory.makeMovie(
+            name: "overlap-video-tracks",
+            videoDuration: TestMovieFactory.videoSpan,
+            audioDuration: nil
+        )
+        defer { TestMovieFactory.cleanup(movieURL) }
+
+        try TestMovieFactory.mutateMovie(at: movieURL) { movie in
+            movie.timescale = 600
+            try TestMovieFactory.addSecondaryVideoTrack(
+                to: movie,
+                at: TestMovieFactory.overlapStart
+            )
+            movie.insertEmptyTimeRange(CMTimeRange(start: .zero, duration: TestMovieFactory.leadingPad))
+        }
+
+        let result = try RecordedMovieTimeRangeNormalizer.normalizeMovie(at: movieURL)
+        XCTAssertTrue(result.didRewrite)
+
+        let movie = try TestMovieFactory.openMovie(at: movieURL)
+        XCTAssertEqual(movie.duration.seconds, TestMovieFactory.overlapExpectedDuration.seconds, accuracy: 0.001)
+
+        let ranges = try TestMovieFactory.trackPresentationRanges(in: movie, characteristic: .visual)
+            .sorted { CMTimeCompare($0.start, $1.start) < 0 }
+        XCTAssertEqual(ranges.count, 2)
+        XCTAssertLessThan(ranges[1].start.seconds, CMTimeRangeGetEnd(ranges[0]).seconds)
+    }
+
+    func testNormalizerUsesEarliestStartLatestEndAcrossVideoTracksWithGap() async throws {
+        let movieURL = try await TestMovieFactory.makeMovie(
+            name: "gap-video-tracks",
+            videoDuration: TestMovieFactory.videoSpan,
+            audioDuration: nil
+        )
+        defer { TestMovieFactory.cleanup(movieURL) }
+
+        try TestMovieFactory.mutateMovie(at: movieURL) { movie in
+            movie.timescale = 600
+            try TestMovieFactory.addSecondaryVideoTrack(
+                to: movie,
+                at: TestMovieFactory.gapStart
+            )
+            movie.insertEmptyTimeRange(CMTimeRange(start: .zero, duration: TestMovieFactory.leadingPad))
+        }
+
+        let result = try RecordedMovieTimeRangeNormalizer.normalizeMovie(at: movieURL)
+        XCTAssertTrue(result.didRewrite)
+
+        let movie = try TestMovieFactory.openMovie(at: movieURL)
+        XCTAssertEqual(movie.duration.seconds, TestMovieFactory.gapExpectedDuration.seconds, accuracy: 0.001)
+
+        let ranges = try TestMovieFactory.trackPresentationRanges(in: movie, characteristic: .visual)
+            .sorted { CMTimeCompare($0.start, $1.start) < 0 }
+        XCTAssertEqual(ranges.count, 2)
+        XCTAssertGreaterThan(ranges[1].start.seconds, CMTimeRangeGetEnd(ranges[0]).seconds)
+    }
+
+    func testCaptureManagerShouldPostProcessRecordedMovieRespectsConditions() throws {
+        let manager = CaptureManager()
+        let existingFileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("post-process-\(UUID().uuidString).tmp")
+        try Data().write(to: existingFileURL)
+        defer { TestMovieFactory.cleanup(existingFileURL) }
+
+        manager.trimsRecordedMovieTimeRangeAfterRecording = true
+
+        XCTAssertFalse(manager.testingShouldPostProcessRecordedMovie(
+            writerError: NSError(domain: "DLABCaptureTests", code: 1),
+            outputURL: existingFileURL
+        ))
+        XCTAssertFalse(manager.testingShouldPostProcessRecordedMovie(
+            writerError: nil,
+            outputURL: nil
+        ))
+        XCTAssertTrue(manager.testingShouldPostProcessRecordedMovie(
+            writerError: nil,
+            outputURL: existingFileURL
+        ))
+    }
+
+    func testCaptureManagerPostProcessStoresLastErrorAndInvokesCallback() async throws {
+        let manager = CaptureManager()
+        let movieURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("missing-\(UUID().uuidString).mov")
+
+        let callbackExpectation = expectation(description: "post-process callback")
+        manager.recordedMoviePostProcessErrorHandler = { callbackURL, error in
+            XCTAssertEqual(callbackURL, movieURL)
+            XCTAssertFalse(error.localizedDescription.isEmpty)
+            callbackExpectation.fulfill()
+        }
+
+        await manager.testingPostProcessRecordedMovieIfNeeded(at: movieURL)
+
+        XCTAssertNotNil(manager.lastRecordedMoviePostProcessError)
+        await fulfillment(of: [callbackExpectation], timeout: 1.0)
+    }
+
+    func testCaptureWriterResolvedMovieURLReturnsGeneratedURLAfterOpenSession() async throws {
+        let writer = CaptureWriter()
+        var config = CaptureWriter.CaptureWriterConfig()
+        config.useAudio = false
+        config.useVideo = false
+        config.useTimecode = false
+        config.movieURL = nil
+
+        await writer.setConfig(config)
+        await writer.openSession()
+
+        let resolvedURL = await writer.resolvedMovieURL()
+        XCTAssertNotNil(resolvedURL)
+    }
+}
+
+private enum TestMovieFactory {
+    static let videoFrameRate: CMTimeScale = 30
+    static let audioSampleRate: CMTimeScale = 48_000
+    static let videoSpan = CMTime(value: 6, timescale: 30)
+    static let longerAudioSpan = CMTime(value: 12_000, timescale: 48_000)
+    static let audioOnlySpan = CMTime(value: 9_600, timescale: 48_000)
+    static let leadingPad = CMTime(value: 3, timescale: 30)
+    static let overlapStart = CMTime(value: 3, timescale: 30)
+    static let gapStart = CMTime(value: 12, timescale: 30)
+    static let overlapExpectedDuration = CMTime(value: 9, timescale: 30)
+    static let gapExpectedDuration = CMTime(value: 18, timescale: 30)
+
+    enum FixtureError: Error {
+        case missingTrack(String)
+        case assetWriterFailure(String)
+        case appendFailure(String)
+        case formatDescriptionFailure(OSStatus)
+        case bufferCreationFailure(OSStatus)
+        case sampleBufferCreationFailure(OSStatus)
+        case pixelBufferCreationFailure(CVReturn)
+    }
+
+    final class AssetWriterBox: @unchecked Sendable {
+        let writer: AVAssetWriter
+
+        init(_ writer: AVAssetWriter) {
+            self.writer = writer
+        }
+    }
+
+    static func makeMovie(name: String,
+                          videoDuration: CMTime?,
+                          audioDuration: CMTime?) async throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(name)-\(UUID().uuidString).mov")
+        try? FileManager.default.removeItem(at: url)
+
+        guard videoDuration != nil || audioDuration != nil else {
+            throw FixtureError.assetWriterFailure("No media tracks were requested.")
+        }
+
+        let writer = try AVAssetWriter(outputURL: url, fileType: .mov)
+        var videoInput: AVAssetWriterInput?
+        var audioInput: AVAssetWriterInput?
+        var pixelBufferAdaptor: AVAssetWriterInputPixelBufferAdaptor?
+
+        if videoDuration != nil {
+            let videoSettings: [String: Any] = [
+                AVVideoCodecKey: AVVideoCodecType.h264,
+                AVVideoWidthKey: 16,
+                AVVideoHeightKey: 16
+            ]
+            let input = AVAssetWriterInput(mediaType: .video, outputSettings: videoSettings)
+            input.expectsMediaDataInRealTime = false
+            guard writer.canAdd(input) else {
+                throw FixtureError.assetWriterFailure("Cannot add video input.")
+            }
+            writer.add(input)
+            videoInput = input
+
+            let pixelBufferAttributes: [String: Any] = [
+                kCVPixelBufferPixelFormatTypeKey as String: Int(kCVPixelFormatType_32ARGB),
+                kCVPixelBufferWidthKey as String: 16,
+                kCVPixelBufferHeightKey as String: 16
+            ]
+            pixelBufferAdaptor = AVAssetWriterInputPixelBufferAdaptor(
+                assetWriterInput: input,
+                sourcePixelBufferAttributes: pixelBufferAttributes
+            )
+        }
+
+        if audioDuration != nil {
+            let audioSettings: [String: Any] = [
+                AVFormatIDKey: kAudioFormatLinearPCM,
+                AVSampleRateKey: audioSampleRate,
+                AVNumberOfChannelsKey: 1,
+                AVLinearPCMBitDepthKey: 16,
+                AVLinearPCMIsBigEndianKey: false,
+                AVLinearPCMIsFloatKey: false,
+                AVLinearPCMIsNonInterleaved: false
+            ]
+            let input = AVAssetWriterInput(mediaType: .audio, outputSettings: audioSettings)
+            input.expectsMediaDataInRealTime = false
+            guard writer.canAdd(input) else {
+                throw FixtureError.assetWriterFailure("Cannot add audio input.")
+            }
+            writer.add(input)
+            audioInput = input
+        }
+
+        guard writer.startWriting() else {
+            throw FixtureError.assetWriterFailure(writer.error?.localizedDescription ?? "startWriting failed")
+        }
+        writer.startSession(atSourceTime: .zero)
+
+        if let videoDuration, let videoInput, let pixelBufferAdaptor {
+            let frameDuration = CMTime(value: 1, timescale: videoFrameRate)
+            let frameCount = max(1, Int(CMTimeConvertScale(videoDuration, timescale: videoFrameRate, method: .default).value))
+
+            for frameIndex in 0..<frameCount {
+                while !videoInput.isReadyForMoreMediaData {
+                    await Task.yield()
+                }
+
+                let pixelBuffer = try makePixelBuffer()
+                let presentationTime = CMTimeMultiply(frameDuration, multiplier: Int32(frameIndex))
+                guard pixelBufferAdaptor.append(pixelBuffer, withPresentationTime: presentationTime) else {
+                    throw FixtureError.appendFailure(writer.error?.localizedDescription ?? "Video append failed.")
+                }
+            }
+        }
+
+        if let audioDuration, let audioInput {
+            while !audioInput.isReadyForMoreMediaData {
+                await Task.yield()
+            }
+
+            let sampleCount = max(1, Int(CMTimeConvertScale(audioDuration, timescale: audioSampleRate, method: .default).value))
+            let sampleBuffer = try makeAudioSampleBuffer(sampleCount: sampleCount, presentationTime: .zero)
+            guard audioInput.append(sampleBuffer) else {
+                throw FixtureError.appendFailure(writer.error?.localizedDescription ?? "Audio append failed.")
+            }
+        }
+
+        let endTime = [videoDuration, audioDuration]
+            .compactMap { $0 }
+            .max { CMTimeCompare($0, $1) < 0 } ?? .zero
+        writer.endSession(atSourceTime: endTime)
+
+        videoInput?.markAsFinished()
+        audioInput?.markAsFinished()
+        try await finishWriting(writer)
+
+        return url
+    }
+
+    static func cleanup(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    static func openMovie(at url: URL) throws -> AVMutableMovie {
+        AVMutableMovie(url: url, options: nil)
+    }
+
+    static func mutateMovie(at url: URL, update: (AVMutableMovie) throws -> Void) throws {
+        let movie = try openMovie(at: url)
+        try update(movie)
+        try movie.writeHeader(to: url, fileType: .mov, options: .addMovieHeaderToDestination)
+    }
+
+    static func addSecondaryVideoTrack(to movie: AVMutableMovie, at startTime: CMTime) throws {
+        guard let sourceTrack = movie.tracks(withMediaCharacteristic: .visual).first else {
+            throw FixtureError.missingTrack("No visual track available.")
+        }
+        guard let sourceRange = presentationRange(for: sourceTrack) else {
+            throw FixtureError.missingTrack("No presentation range available for source visual track.")
+        }
+        guard let newTrack = movie.addMutableTrack(withMediaType: .video, copySettingsFrom: sourceTrack, options: nil) else {
+            throw FixtureError.assetWriterFailure("Failed to create secondary video track.")
+        }
+        try newTrack.insertTimeRange(sourceRange, of: sourceTrack, at: startTime, copySampleData: false)
+    }
+
+    static func trackPresentationRanges(in movie: AVMutableMovie,
+                                        characteristic: AVMediaCharacteristic) throws -> [CMTimeRange] {
+        movie.tracks(withMediaCharacteristic: characteristic).compactMap { track in
+            guard let range = presentationRange(for: track) else {
+                return nil
+            }
+            return range
+        }
+    }
+
+    private static func presentationRange(for track: AVMutableMovieTrack) -> CMTimeRange? {
+        var unionRange: CMTimeRange?
+        for segment in track.segments where !segment.isEmpty {
+            let targetRange = segment.timeMapping.target
+            guard targetRange.isValid, !targetRange.isEmpty else { continue }
+            if let current = unionRange {
+                unionRange = CMTimeRangeGetUnion(current, otherRange: targetRange)
+            } else {
+                unionRange = targetRange
+            }
+        }
+        return unionRange
+    }
+
+    private static func finishWriting(_ writer: AVAssetWriter) async throws {
+        let writerBox = AssetWriterBox(writer)
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            writer.finishWriting {
+                if let error = writerBox.writer.error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+
+    private static func makePixelBuffer() throws -> CVPixelBuffer {
+        var pixelBuffer: CVPixelBuffer?
+        let attributes: [CFString: Any] = [
+            kCVPixelBufferCGImageCompatibilityKey: true,
+            kCVPixelBufferCGBitmapContextCompatibilityKey: true
+        ]
+        let status = CVPixelBufferCreate(kCFAllocatorDefault,
+                                         16,
+                                         16,
+                                         kCVPixelFormatType_32ARGB,
+                                         attributes as CFDictionary,
+                                         &pixelBuffer)
+        guard status == kCVReturnSuccess, let pixelBuffer else {
+            throw FixtureError.pixelBufferCreationFailure(status)
+        }
+
+        CVPixelBufferLockBaseAddress(pixelBuffer, [])
+        defer { CVPixelBufferUnlockBaseAddress(pixelBuffer, []) }
+
+        if let baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer) {
+            memset(baseAddress, 0, CVPixelBufferGetBytesPerRow(pixelBuffer) * CVPixelBufferGetHeight(pixelBuffer))
+        }
+
+        return pixelBuffer
+    }
+
+    private static func makeAudioSampleBuffer(sampleCount: Int,
+                                              presentationTime: CMTime) throws -> CMSampleBuffer {
+        var asbd = AudioStreamBasicDescription(
+            mSampleRate: Float64(audioSampleRate),
+            mFormatID: kAudioFormatLinearPCM,
+            mFormatFlags: kLinearPCMFormatFlagIsSignedInteger | kLinearPCMFormatFlagIsPacked,
+            mBytesPerPacket: 2,
+            mFramesPerPacket: 1,
+            mBytesPerFrame: 2,
+            mChannelsPerFrame: 1,
+            mBitsPerChannel: 16,
+            mReserved: 0
+        )
+
+        var formatDescription: CMAudioFormatDescription?
+        let formatStatus = CMAudioFormatDescriptionCreate(
+            allocator: kCFAllocatorDefault,
+            asbd: &asbd,
+            layoutSize: 0,
+            layout: nil,
+            magicCookieSize: 0,
+            magicCookie: nil,
+            extensions: nil,
+            formatDescriptionOut: &formatDescription
+        )
+        guard formatStatus == noErr, let formatDescription else {
+            throw FixtureError.formatDescriptionFailure(formatStatus)
+        }
+
+        let dataSize = sampleCount * 2
+        var blockBuffer: CMBlockBuffer?
+        let blockStatus = CMBlockBufferCreateWithMemoryBlock(
+            allocator: kCFAllocatorDefault,
+            memoryBlock: nil,
+            blockLength: dataSize,
+            blockAllocator: nil,
+            customBlockSource: nil,
+            offsetToData: 0,
+            dataLength: dataSize,
+            flags: 0,
+            blockBufferOut: &blockBuffer
+        )
+        guard blockStatus == kCMBlockBufferNoErr, let blockBuffer else {
+            throw FixtureError.bufferCreationFailure(blockStatus)
+        }
+
+        let zeroes = [UInt8](repeating: 0, count: dataSize)
+        let replaceStatus = CMBlockBufferReplaceDataBytes(
+            with: zeroes,
+            blockBuffer: blockBuffer,
+            offsetIntoDestination: 0,
+            dataLength: dataSize
+        )
+        guard replaceStatus == kCMBlockBufferNoErr else {
+            throw FixtureError.bufferCreationFailure(replaceStatus)
+        }
+
+        var timingInfo = CMSampleTimingInfo(
+            duration: CMTime(value: 1, timescale: audioSampleRate),
+            presentationTimeStamp: presentationTime,
+            decodeTimeStamp: .invalid
+        )
+        var sampleSize = 2
+        var sampleBuffer: CMSampleBuffer?
+        let sampleStatus = CMSampleBufferCreateReady(
+            allocator: kCFAllocatorDefault,
+            dataBuffer: blockBuffer,
+            formatDescription: formatDescription,
+            sampleCount: sampleCount,
+            sampleTimingEntryCount: 1,
+            sampleTimingArray: &timingInfo,
+            sampleSizeEntryCount: 1,
+            sampleSizeArray: &sampleSize,
+            sampleBufferOut: &sampleBuffer
+        )
+        guard sampleStatus == noErr, let sampleBuffer else {
+            throw FixtureError.sampleBufferCreationFailure(sampleStatus)
+        }
+
+        return sampleBuffer
+    }
+}

--- a/Tests/DLABCaptureTests/RecordedMovieTimeRangeNormalizerTests.swift
+++ b/Tests/DLABCaptureTests/RecordedMovieTimeRangeNormalizerTests.swift
@@ -198,6 +198,23 @@ final class RecordedMovieTimeRangeNormalizerTests: XCTestCase {
         await fulfillment(of: [callbackExpectation], timeout: 1.0)
     }
 
+    func testCaptureManagerSkippedPostProcessClearsStaleError() async throws {
+        let manager = CaptureManager()
+        manager.trimsRecordedMovieTimeRangeAfterRecording = true
+
+        let missingURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("missing-\(UUID().uuidString).mov")
+        await manager.testingPostProcessRecordedMovieIfNeeded(at: missingURL)
+        XCTAssertNotNil(manager.lastRecordedMoviePostProcessError)
+
+        await manager.testingHandleRecordedMoviePostProcess(
+            writerError: NSError(domain: "DLABCaptureTests", code: 2),
+            outputURL: nil
+        )
+
+        XCTAssertNil(manager.lastRecordedMoviePostProcessError)
+    }
+
     func testCaptureWriterResolvedMovieURLReturnsGeneratedURLAfterOpenSession() async throws {
         let writer = CaptureWriter()
         var config = CaptureWriter.CaptureWriterConfig()

--- a/Tests/DLABCaptureTests/RecordedMovieTimeRangeNormalizerTests.swift
+++ b/Tests/DLABCaptureTests/RecordedMovieTimeRangeNormalizerTests.swift
@@ -85,6 +85,20 @@ final class RecordedMovieTimeRangeNormalizerTests: XCTestCase {
         XCTAssertEqual(result.mediaKind, .video)
     }
 
+    func testNormalizerRejectsNonRegularFilePath() throws {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("movie-normalizer-directory-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        defer { TestMovieFactory.cleanup(directoryURL) }
+
+        XCTAssertThrowsError(try RecordedMovieTimeRangeNormalizer.normalizeMovie(at: directoryURL)) { error in
+            guard case let RecordedMovieTimeRangeNormalizationError.movieOpenFailed(reason) = error else {
+                return XCTFail("Expected movieOpenFailed for directory URL, got \(error)")
+            }
+            XCTAssertTrue(reason.contains("regular file"))
+        }
+    }
+
     func testNormalizerUsesEarliestStartLatestEndAcrossOverlappingVideoTracks() async throws {
         let movieURL = try await TestMovieFactory.makeMovie(
             name: "overlap-video-tracks",


### PR DESCRIPTION
## Summary

- add recorded movie range normalization support for `.mov` outputs via `CaptureManager.normalizeRecordedMovieTimeRange(at:)`
- add an opt-in automatic post-save trimming path after recording completes, with error callback and last-error tracking
- add regression tests covering leading/trailing trim, audio fallback, multi-track overlap/gap, and post-process error handling
- include related cleanup/cosmetic adjustments in `AudioChannelLayoutHelper`, `CaptureWriter`, and surrounding capture plumbing

## Testing

- `swift build`
- `swift test`
- `xcodebuild analyze -workspace .swiftpm/xcode/package.xcworkspace -scheme DLAB-Package -destination 'generic/platform=macOS'`
