### PR TITLE
stabilize capture concurrency and refactor DeckLink bridging

### DIFF
--- a/Sources/DLABCapture/AudioChannelLayoutHelper.swift
+++ b/Sources/DLABCapture/AudioChannelLayoutHelper.swift
@@ -562,8 +562,8 @@ extension CaptureWriter {
             return MemoryLayout<AudioChannelLayout>.size
         }
         
-        return MemoryLayout<AudioChannelLayout>.size +
-               (channelDescriptionCount - 1) * MemoryLayout<AudioChannelDescription>.size
+        return (MemoryLayout<AudioChannelLayout>.size +
+                (channelDescriptionCount - 1) * MemoryLayout<AudioChannelDescription>.size)
     }
     
     /// Get pointer to the channel descriptions array in the input AudioChannelLayout.

--- a/Sources/DLABCapture/CaptureAudioPreview.swift
+++ b/Sources/DLABCapture/CaptureAudioPreview.swift
@@ -233,7 +233,7 @@ class CaptureAudioPreview: NSObject, @unchecked Sendable {
         let desc = description ?? "unknown description"
         let reason = failureReason ?? "unknown failureReason"
         let userInfo :[String:Any] = [NSLocalizedDescriptionKey:desc,
-                                      NSLocalizedFailureReasonErrorKey:reason]
+                               NSLocalizedFailureReasonErrorKey:reason]
         return NSError(domain: domain, code: code, userInfo: userInfo)
     }
     

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -29,7 +29,6 @@ public struct UnsafeSampleBufferWrapper: @unchecked Sendable {
 public struct UnsafeSampleBufferInfo: @unchecked Sendable {
     var sampleBuffer: CMSampleBuffer
     var setting: DLABTimecodeSetting?
-    var sender: DLABDevice
 }
 
 /// Specify preferred timecodeSource.
@@ -70,6 +69,9 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         var timecodeReady: Bool = false
         var lastDuration: Float64 = 0.0
         var lastRecordedMoviePostProcessError: Error? = nil
+        var currentDevice: DLABDevice? = nil
+        var audioCaptureEnabled: Bool = false
+        var videoCaptureEnabled: Bool = false
     }
     
     /// Verbose mode (debugging purpose)
@@ -93,27 +95,17 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
             runtimeState[keyPath: keyPath]
         }
     }
-    
-    private func setRunning(_ newValue: Bool) {
-        withRuntimeState { $0.running = newValue }
-    }
-    
-    private func setRecording(_ newValue: Bool) {
-        withRuntimeState { $0.recording = newValue }
-    }
-    
-    private func setTimecodeReady(_ newValue: Bool) {
-        withRuntimeState { $0.timecodeReady = newValue }
-    }
-    
     /// True while capture is running
-    public var running: Bool {
-        runtimeStateValue(\.running)
+    public private(set) var running: Bool {
+        get { runtimeStateValue(\.running) }
+        set { withRuntimeState { $0.running = newValue } }
     }
     
     /// Capture device as DLABDevice object
-    public var currentDevice: DLABDevice? = nil
-    
+    public internal(set) var currentDevice: DLABDevice? {
+        get { runtimeStateValue(\.currentDevice) }
+        set { withRuntimeState { $0.currentDevice = newValue } }
+    }
     /* ============================================ */
     // MARK: - properties - Capturing audio
     /* ============================================ */
@@ -136,9 +128,8 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     public var volume: Float = 1.0 {
         didSet {
             volume = max(0.0, min(1.0, volume))
-            
-            if let audioPreview = audioPreview {
-                audioPreview.volume = Float32(volume)
+            if let preview = currentAudioPreview() {
+                preview.volume = Float32(volume)
             }
         }
     }
@@ -150,11 +141,37 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     public var reverseCh3Ch4: Bool = false
     
     /// True while audio capture is enabled
-    public private(set) var audioCaptureEnabled: Bool = false
-    
+    public private(set) var audioCaptureEnabled: Bool {
+        get { runtimeStateValue(\.audioCaptureEnabled) }
+        set { withRuntimeState { $0.audioCaptureEnabled = newValue } }
+    }
     /// AudioPreview object
-    private var audioPreview: CaptureAudioPreview? = nil
+    private let audioPreviewLock = UnfairLockBox()
+    private var audioPreviewStorage: CaptureAudioPreview? = nil
+    private var previewDisposed: Bool = false
     
+    private func currentAudioPreview() -> CaptureAudioPreview? {
+        audioPreviewLock.withLock {
+            previewDisposed ? nil : audioPreviewStorage
+        }
+    }
+    
+    private func setAudioPreview(_ preview: CaptureAudioPreview?) {
+        audioPreviewLock.withLock {
+            audioPreviewStorage = preview
+            previewDisposed = false
+        }
+    }
+    
+    private func takeAudioPreview() -> CaptureAudioPreview? {
+        audioPreviewLock.withLock {
+            guard !previewDisposed else { return nil }
+            let preview = audioPreviewStorage
+            audioPreviewStorage = nil
+            previewDisposed = true
+            return preview
+        }
+    }
     /* ============================================ */
     // MARK: - properties - Capturing video
     /* ============================================ */
@@ -177,8 +194,10 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     public var videoConnection: DLABVideoConnection = .init()
     
     /// True while video capture is enabled
-    public private(set) var videoCaptureEnabled: Bool = false
-    
+    public private(set) var videoCaptureEnabled: Bool {
+        get { runtimeStateValue(\.videoCaptureEnabled) }
+        set { withRuntimeState { $0.videoCaptureEnabled = newValue } }
+    }
     /// Set CaptureVideoPreview view here - based on AVSampleBufferDisplayLayer
     public weak var videoPreview: CaptureVideoPreview? = nil
     
@@ -205,8 +224,9 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     /* ============================================ */
     
     /// True while recording
-    public var recording: Bool {
-        runtimeStateValue(\.recording)
+    public private(set) var recording: Bool {
+        get { runtimeStateValue(\.recording) }
+        set { withRuntimeState { $0.recording = newValue } }
     }
     
     /// Protects recording writer state across callback tasks and state transitions.
@@ -258,7 +278,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     public var sampleTimescale :CMTimeScale = 0
     
     /// Duration in sec of last recording
-    private var lastDuration :Float64 {
+    private var lastDuration: Float64 {
         get { runtimeStateValue(\.lastDuration) }
         set { withRuntimeState { $0.lastDuration = newValue } }
     }
@@ -344,13 +364,26 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     /* ============================================ */
     
     /// True if input provides timecode data
-    public var timecodeReady :Bool {
-        runtimeStateValue(\.timecodeReady)
+    public private(set) var timecodeReady: Bool {
+        get { runtimeStateValue(\.timecodeReady) }
+        set { withRuntimeState { $0.timecodeReady = newValue } }
     }
     
     /// Timecode helper object
-    private var timecodeHelper :CaptureTimecodeHelper? = nil
+    private let timecodeHelperLock = UnfairLockBox()
+    private var timecodeHelperStorage: CaptureTimecodeHelper? = nil
     
+    private func currentTimecodeHelper() -> CaptureTimecodeHelper? {
+        timecodeHelperLock.withLock { timecodeHelperStorage }
+    }
+    
+    private func setTimecodeHelper(_ helper: CaptureTimecodeHelper?) {
+        timecodeHelperLock.withLock { timecodeHelperStorage = helper }
+    }
+    
+    private func clearTimecodeHelper() {
+        timecodeHelperLock.withLock { timecodeHelperStorage = nil }
+    }
     /// Timecode format type (timecode
     public var timecodeFormatType : CMTimeCodeFormatType = kCMTimeCodeFormatType_TimeCode32
     
@@ -402,7 +435,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         if let device = currentDevice, running == false {
             if timecodeSource != nil {
                 // support for timecode
-                setTimecodeReady(false)
+                timecodeReady = false
                 prepTimecodeHelper()
             }
             
@@ -486,10 +519,11 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                 if let aSetting = aSetting {
                     // Enable Audio Preview
                     if let audioFormatDescription = aSetting.audioFormatDescription {
-                        audioPreview = CaptureAudioPreview(audioFormatDescription)
-                        if let audioPreview = audioPreview {
-                            audioPreview.volume = Float32(volume)
+                        let preview = CaptureAudioPreview(audioFormatDescription)
+                        if let preview = preview {
+                            preview.volume = Float32(volume)
                         }
+                        setAudioPreview(preview)
                     }
                     
                     // Enable Audio Capture
@@ -509,7 +543,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                     // Start stream
                     device.inputDelegate = self
                     try device.startStreams()
-                    setRunning(true)
+                    running = true
                 }
                 
                 if running {
@@ -537,7 +571,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
             
             do {
                 // Stop stream
-                setRunning(false)
+                running = false
                 try device.stopStreams()
                 device.inputDelegate = nil
                 clearInputAncillaryPacketHandler(from: device)
@@ -559,10 +593,9 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                 if let _ = parentView {
                     try await attachInputScreenPreview(to: nil) // @MainActor
                 }
-                if let audioPreview = audioPreview {
-                    try audioPreview.aqStop()
-                    try audioPreview.aqDispose()
-                    self.audioPreview = nil
+                if let preview = takeAudioPreview() {
+                    try preview.aqStop()
+                    try preview.aqDispose()
                 }
             } catch let error as NSError {
                 printVerbose("ERROR:CaptureManager.\(#function) - \(error.domain)(\(error.code)): \(error.localizedFailureReason ?? "unknown reason")")
@@ -570,8 +603,8 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
             
             do {
                 // support for timecode
-                setTimecodeReady(false)
-                timecodeHelper = nil
+                timecodeReady = false
+                clearTimecodeHelper()
             }
             
             if !running {
@@ -606,7 +639,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                 writerPrepared = (writer != nil)
                 
                 if recording {
-                    setRecording(false)
+                    recording = false
                 }
                 
                 printVerbose("CaptureManager.\(#function) - Stop recording completed")
@@ -636,7 +669,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                     
                     if await writer.isRecording {
                         appendGateOpen = true
-                        setRecording(true)
+                        recording = true
                         writerPrepared = true
                         // print("NOTICE: Recording started")
                         
@@ -715,8 +748,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         let writer = self.writer
         let videoPreview = self.videoPreview
         let parentView = self.parentView
-        let audioPreview = self.audioPreview
-        
+        let audioPreview = takeAudioPreview()
         let isRunning = self.running
         let isRecording = self.recording
         let isVideoCaptureEnabled = self.videoCaptureEnabled
@@ -842,22 +874,19 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     internal func testingShouldPostProcessRecordedMovie(writerError: Error?, outputURL: URL?) -> Bool {
         shouldPostProcessRecordedMovie(writerError: writerError, outputURL: outputURL)
     }
-
+    
     internal func testingHandleRecordedMoviePostProcess(writerError: Error?, outputURL: URL?) async {
         await handleRecordedMoviePostProcess(writerError: writerError, outputURL: outputURL)
     }
-
+    
     internal func testingPostProcessRecordedMovieIfNeeded(at movieURL: URL) async {
         await postProcessRecordedMovieIfNeeded(at: movieURL)
     }
     
     private func prepTimecodeHelper() {
         if let timecodeSource = timecodeSource, timecodeSource == .CoreAudio {
-            if let timecodeHelper = timecodeHelper {
-                timecodeHelper.timeCodeFormatType = timecodeFormatType
-            } else {
-                timecodeHelper = CaptureTimecodeHelper(formatType: timecodeFormatType)
-            }
+            // Replace atomically to avoid racing with concurrent createTimeCodeSample(from:) reads.
+            setTimecodeHelper(CaptureTimecodeHelper(formatType: timecodeFormatType))
         }
     }
     
@@ -901,15 +930,15 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         
         return true
     }
-
+    
     private func handleRecordedMoviePostProcess(writerError: Error?, outputURL: URL?) async {
         lastRecordedMoviePostProcessError = nil
-
+        
         guard let outputURL,
               shouldPostProcessRecordedMovie(writerError: writerError, outputURL: outputURL) else {
             return
         }
-
+        
         await postProcessRecordedMovieIfNeeded(at: outputURL)
     }
     
@@ -935,7 +964,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     ///   - sender: DLABDevice
     public nonisolated func processCapturedAudioSample(_ sampleBuffer: CMSampleBuffer,
                                                        of sender:DLABDevice) {
-        let info = UnsafeSampleBufferInfo(sampleBuffer: sampleBuffer, setting: nil, sender: sender)
+        let info = UnsafeSampleBufferInfo(sampleBuffer: sampleBuffer, setting: nil)
         Task(priority: .high) {
             await processCapturedAudioSampleAsync(info)
         }
@@ -947,7 +976,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     ///   - sender: DLABDevice
     public nonisolated func processCapturedVideoSample(_ sampleBuffer: CMSampleBuffer,
                                                        of sender:DLABDevice) {
-        let info = UnsafeSampleBufferInfo(sampleBuffer: sampleBuffer, setting: nil, sender: sender)
+        let info = UnsafeSampleBufferInfo(sampleBuffer: sampleBuffer, setting: nil)
         Task(priority: .high) {
             await processCapturedVideoSampleAsync(info)
         }
@@ -961,7 +990,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     public nonisolated func processCapturedVideoSample(_ sampleBuffer: CMSampleBuffer,
                                                        timecodeSetting setting: DLABTimecodeSetting,
                                                        of sender:DLABDevice) {
-        let info = UnsafeSampleBufferInfo(sampleBuffer: sampleBuffer, setting: setting, sender: sender)
+        let info = UnsafeSampleBufferInfo(sampleBuffer: sampleBuffer, setting: setting)
         Task(priority: .high) {
             await processCapturedVideoSampleAsync(info)
         }
@@ -980,13 +1009,13 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                 printVerbose("ERROR:CaptureManager.\(#function) - audio append failed: \(error.localizedDescription)")
             }
         }
-        if let audioPreview = audioPreview {
-            if audioPreview.running == true {
-                try? audioPreview.enqueue(sampleBuffer)
+        if let preview = currentAudioPreview() {
+            if preview.running == true {
+                try? preview.enqueue(sampleBuffer)
             } else {
-                try? audioPreview.enqueue(sampleBuffer)
-                try? audioPreview.aqPrime()
-                try? audioPreview.aqStart()
+                try? preview.enqueue(sampleBuffer)
+                try? preview.aqPrime()
+                try? preview.aqStart()
             }
         }
     }
@@ -1030,15 +1059,15 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                     
                     // source provides timecode
                     if timecodeReady == false {
-                        setTimecodeReady(true)
+                        timecodeReady = true
                         printVerbose("NOTICE: timecodeReady : \(timecodeSource)")
                     }
                 }
             }
         } else {
             // support for core_audio_smpte_time
-            if let timecodeSource = timecodeSource, timecodeSource == .CoreAudio, let timecodeHelper = timecodeHelper {
-                let timecodeSampleBuffer = timecodeHelper.createTimeCodeSample(from: sampleBuffer)
+            if let timecodeSource = timecodeSource, timecodeSource == .CoreAudio, let helper = currentTimecodeHelper() {
+                let timecodeSampleBuffer = helper.createTimeCodeSample(from: sampleBuffer)
                 if let timecodeSampleBuffer = timecodeSampleBuffer {
                     if let writer = currentAppendWriter() {
                         let wrapper = UnsafeSampleBufferWrapper(sampleBuffer: timecodeSampleBuffer)
@@ -1051,7 +1080,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                     
                     // source provides timecode
                     if timecodeReady == false {
-                        setTimecodeReady(true)
+                        timecodeReady = true
                         printVerbose("NOTICE: timecodeReady : core_audio_smpte_time")
                     }
                 }

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -1072,6 +1072,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     ///   - sender: DLABDevice
     public nonisolated func processCapturedAudioSample(_ sampleBuffer: CMSampleBuffer,
                                                        of sender:DLABDevice) {
+        guard sender === currentDevice, running else { return }
         let info = UnsafeSampleBufferInfo(sampleBuffer: sampleBuffer, setting: nil)
         let enqueued = audioQueue.enqueue { [weak self] in
             await self?.processCapturedAudioSampleAsync(info)
@@ -1088,6 +1089,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     ///   - sender: DLABDevice
     public nonisolated func processCapturedVideoSample(_ sampleBuffer: CMSampleBuffer,
                                                        of sender:DLABDevice) {
+        guard sender === currentDevice, running else { return }
         let info = UnsafeSampleBufferInfo(sampleBuffer: sampleBuffer, setting: nil)
         let enqueued = videoQueue.enqueue { [weak self] in
             await self?.processCapturedVideoSampleAsync(info)
@@ -1106,6 +1108,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     public nonisolated func processCapturedVideoSample(_ sampleBuffer: CMSampleBuffer,
                                                        timecodeSetting setting: DLABTimecodeSetting,
                                                        of sender:DLABDevice) {
+        guard sender === currentDevice, running else { return }
         let info = UnsafeSampleBufferInfo(sampleBuffer: sampleBuffer, setting: setting)
         let enqueued = videoQueue.enqueue { [weak self] in
             await self?.processCapturedVideoSampleAsync(info)

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -54,6 +54,54 @@ public enum TimecodeType: Int, Sendable {
     }
 }
 
+// MARK: - Bounded Sample Processing Queue
+
+/// A lock-protected bounded work queue for callback-driven sample processing.
+///
+/// Each lane (audio, video) gets its own queue instance.  `maxDepth` is a hard
+/// limit — when the queue is full, `enqueue` returns `false` and the caller
+/// drops the sample.  This prevents unbounded task creation and memory growth
+/// under sustained overload.
+///
+/// Work is drained in FIFO batches: items within a single batch are processed
+/// in enqueue order, but a new batch may include items that arrived while the
+/// previous batch was executing.  Ordering across batch boundaries is still
+/// FIFO, so the net effect is FIFO within each lane.
+///
+/// Queued closures capture `self` weakly; work may be silently dropped during
+/// teardown / deinit when the `CaptureManager` is no longer alive.
+private final class BoundedWorkQueue: @unchecked Sendable {
+    private let lock = UnfairLockBox()
+    private var items: [@Sendable () async -> Void] = []
+    let maxDepth: Int
+    
+    init(maxDepth: Int) {
+        self.maxDepth = maxDepth
+    }
+    
+    /// Attempt to enqueue a work item.
+    ///
+    /// Returns `true` on success.  Returns `false` when the queue is full;
+    /// the caller should drop the sample.  Never blocks.
+    func enqueue(_ work: @escaping @Sendable () async -> Void) -> Bool {
+        lock.withLock {
+            guard items.count < maxDepth else { return false }
+            items.append(work)
+            return true
+        }
+    }
+    
+    /// Atomically drain all queued items.
+    func takeAll() -> [@Sendable () async -> Void] {
+        lock.withLock {
+            guard !items.isEmpty else { return [] }
+            let result = items
+            items = []
+            return result
+        }
+    }
+}
+
 /// Extension to make CaptureManager conform to Sendable for cross-actor usage.
 /// Note: This is marked as @unchecked because CaptureManager contains non-Sendable
 /// properties, but the class is designed to be used safely across actor boundaries
@@ -76,6 +124,15 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     
     /// Verbose mode (debugging purpose)
     public var verbose: Bool = false
+    
+    /* ============================================ */
+    // MARK: - properties - Sample processing backpressure
+    /* ============================================ */
+    
+    private let audioQueue = BoundedWorkQueue(maxDepth: 4)
+    private let videoQueue = BoundedWorkQueue(maxDepth: 4)
+    private var audioProcessorTask: Task<Void, Never>?
+    private var videoProcessorTask: Task<Void, Never>?
     
     /* ============================================ */
     // MARK: - properties - Capturing
@@ -412,6 +469,34 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         super.init()
         
         // print("CaptureManager.\(#function)")
+        
+        // NOTE: idle wakeup uses Task.yield(); a future refinement could
+        // use a continuation-based signal instead of a spin-yield loop.
+        audioProcessorTask = Task(priority: .high) { [audioQueue] in
+            while !Task.isCancelled {
+                let batch = audioQueue.takeAll()
+                if batch.isEmpty {
+                    await Task.yield()
+                    continue
+                }
+                for work in batch {
+                    await work()
+                }
+            }
+        }
+        
+        videoProcessorTask = Task(priority: .high) { [videoQueue] in
+            while !Task.isCancelled {
+                let batch = videoQueue.takeAll()
+                if batch.isEmpty {
+                    await Task.yield()
+                    continue
+                }
+                for work in batch {
+                    await work()
+                }
+            }
+        }
     }
     
     deinit {
@@ -741,6 +826,9 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     
     /// deinit helper method for cleanup.
     private func detachedCleanup() {
+        audioProcessorTask?.cancel()
+        videoProcessorTask?.cancel()
+        
         // Copy actor isolated properties to nonisolated variables
         let verbose = self.verbose
         
@@ -965,8 +1053,12 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     public nonisolated func processCapturedAudioSample(_ sampleBuffer: CMSampleBuffer,
                                                        of sender:DLABDevice) {
         let info = UnsafeSampleBufferInfo(sampleBuffer: sampleBuffer, setting: nil)
-        Task(priority: .high) {
-            await processCapturedAudioSampleAsync(info)
+        let enqueued = audioQueue.enqueue { [weak self] in
+            await self?.processCapturedAudioSampleAsync(info)
+        }
+        if !enqueued {
+            // Audio queue full — drop sample under backpressure.
+            // Also implicitly dropped during teardown when self is nil.
         }
     }
     
@@ -977,8 +1069,12 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     public nonisolated func processCapturedVideoSample(_ sampleBuffer: CMSampleBuffer,
                                                        of sender:DLABDevice) {
         let info = UnsafeSampleBufferInfo(sampleBuffer: sampleBuffer, setting: nil)
-        Task(priority: .high) {
-            await processCapturedVideoSampleAsync(info)
+        let enqueued = videoQueue.enqueue { [weak self] in
+            await self?.processCapturedVideoSampleAsync(info)
+        }
+        if !enqueued {
+            // Video queue full — drop sample under backpressure.
+            // Also implicitly dropped during teardown when self is nil.
         }
     }
     
@@ -991,8 +1087,12 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                                                        timecodeSetting setting: DLABTimecodeSetting,
                                                        of sender:DLABDevice) {
         let info = UnsafeSampleBufferInfo(sampleBuffer: sampleBuffer, setting: setting)
-        Task(priority: .high) {
-            await processCapturedVideoSampleAsync(info)
+        let enqueued = videoQueue.enqueue { [weak self] in
+            await self?.processCapturedVideoSampleAsync(info)
+        }
+        if !enqueued {
+            // Video queue full — drop sample under backpressure.
+            // Also implicitly dropped during teardown when self is nil.
         }
     }
     

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -103,9 +103,26 @@ private final class BoundedWorkQueue: @unchecked Sendable {
 }
 
 /// Extension to make CaptureManager conform to Sendable for cross-actor usage.
-/// Note: This is marked as @unchecked because CaptureManager contains non-Sendable
-/// properties, but the class is designed to be used safely across actor boundaries
-/// through careful state management and synchronization.
+///
+/// Concurrency model — mutable state falls into these categories:
+///
+/// - Lock-protected runtime state: managed via ``UnfairLockBox`` and
+///   ``CaptureRuntimeState`` (e.g. running, recording, timecodeReady).
+/// - Set-before-capture configuration: audio/video/encoder parameters
+///   expected to be configured before ``captureStartAsync()`` and not
+///   mutated concurrently during capture.
+/// - UI / MainActor references: ``videoPreview`` and ``parentView`` are
+///   weak and expected to be read/written on the main thread / actor.
+/// - Callback references: ``inputAncillaryPacketHandler``,
+///   ``recordedMoviePostProcessErrorHandler``, and
+///   ``captureWriterDiagnosticHandler`` are controlled-mutation
+///   callbacks.
+/// - Backpressure / queue state: ``BoundedWorkQueue`` instances are
+///   lock-protected and shared between callback threads and persistent
+///   processor ``Task``s.
+///
+/// Marked `@unchecked Sendable` because the class contains non-Sendable
+/// stored properties whose safety is guaranteed by these conventions.
 extension CaptureManager: @unchecked Sendable {
 }
 
@@ -135,7 +152,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     private var videoProcessorTask: Task<Void, Never>?
     
     /* ============================================ */
-    // MARK: - properties - Capturing
+    // MARK: - properties - Lock-protected runtime state
     /* ============================================ */
     
     private let stateLock = UnfairLockBox()
@@ -164,7 +181,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         set { withRuntimeState { $0.currentDevice = newValue } }
     }
     /* ============================================ */
-    // MARK: - properties - Capturing audio
+    // MARK: - properties - Capturing audio (set before capture)
     /* ============================================ */
     
     /// Capture audio bit depth (See DLABConstants.h)
@@ -230,7 +247,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         }
     }
     /* ============================================ */
-    // MARK: - properties - Capturing video
+    // MARK: - properties - Capturing video (set before capture)
     /* ============================================ */
     
     /// Capture video DLABDisplayMode. (See DLABConstants.h)
@@ -255,10 +272,12 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         get { runtimeStateValue(\.videoCaptureEnabled) }
         set { withRuntimeState { $0.videoCaptureEnabled = newValue } }
     }
-    /// Set CaptureVideoPreview view here - based on AVSampleBufferDisplayLayer
+    /// Set CaptureVideoPreview view here - based on AVSampleBufferDisplayLayer.
+    /// Expected to be read/written on the `@MainActor`.
     public weak var videoPreview: CaptureVideoPreview? = nil
     
-    /// Parent NSView for video preview - based on CreateCocoaScreenPreview()
+    /// Parent NSView for video preview - based on CreateCocoaScreenPreview().
+    /// Expected to be read/written on the `@MainActor`.
     public weak var parentView: NSView? = nil {
         didSet {
             Task { @MainActor in
@@ -417,7 +436,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     public var updateVideoSettings : (@Sendable ([String:Any]) -> [String:Any])? = nil
     
     /* ============================================ */
-    // MARK: - properties - Recording timecode
+    // MARK: - properties - Recording timecode (set before capture)
     /* ============================================ */
     
     /// True if input provides timecode data
@@ -441,10 +460,10 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     private func clearTimecodeHelper() {
         timecodeHelperLock.withLock { timecodeHelperStorage = nil }
     }
-    /// Timecode format type (timecode
+    /// Timecode format type. Set before ``captureStartAsync()``.
     public var timecodeFormatType : CMTimeCodeFormatType = kCMTimeCodeFormatType_TimeCode32
     
-    /// Validate if source provides timecode of specified type. Set before captureStart().
+    /// Validate if source provides timecode of specified type. Set before ``captureStartAsync()``.
     public var timecodeSource :TimecodeType? = nil
     
     /* ============================================ */
@@ -453,6 +472,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     
     /// Input ancillary packet callback. Use `dataSpace` to distinguish VANC and HANC packets.
     /// This is the preferred wrapper API for SDK 15.3+ ancillary packet capture.
+    /// Set before or during capture; `didSet` immediately applies to the current device.
     public var inputAncillaryPacketHandler: InputAncillaryPacketHandler? = nil {
         didSet {
             if let device = currentDevice {

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -1120,7 +1120,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     }
     
     /// Audio SampleBuffer callback - Enqueue immediately
-    /// - Parameter info: A wrapper for sampleBuffer and sender
+    /// - Parameter info: A wrapper for sampleBuffer and optional timecode setting
     private func processCapturedAudioSampleAsync(_ info: UnsafeSampleBufferInfo) async {
         let sampleBuffer = info.sampleBuffer
         

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -850,7 +850,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         running = false
         _ = audioQueue.takeAll()
         _ = videoQueue.takeAll()
-
+        
         audioProcessorTask?.cancel()
         videoProcessorTask?.cancel()
         

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -846,6 +846,11 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     
     /// deinit helper method for cleanup.
     private func detachedCleanup() {
+        appendGateOpen = false
+        running = false
+        _ = audioQueue.takeAll()
+        _ = videoQueue.takeAll()
+
         audioProcessorTask?.cancel()
         videoProcessorTask?.cancel()
         
@@ -1122,6 +1127,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     /// Audio SampleBuffer callback - Enqueue immediately
     /// - Parameter info: A wrapper for sampleBuffer and optional timecode setting
     private func processCapturedAudioSampleAsync(_ info: UnsafeSampleBufferInfo) async {
+        guard running else { return }
         let sampleBuffer = info.sampleBuffer
         
         if let writer = currentAppendWriter() {
@@ -1146,6 +1152,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     /// Video SampleBuffer callback - Enqueue immediately Or using DisplayLink
     /// - Parameter info: Video SampleBuffer wrapper
     private func processCapturedVideoSampleAsync(_ info: UnsafeSampleBufferInfo) async {
+        guard running else { return }
         let sampleBuffer = info.sampleBuffer
         let setting = info.setting
         

--- a/Sources/DLABCapture/CaptureTimecodeHelper.swift
+++ b/Sources/DLABCapture/CaptureTimecodeHelper.swift
@@ -56,7 +56,7 @@ class CaptureTimecodeHelper: NSObject {
         
         // Extract SMPTETime from video sample
         guard let smpteTime = extractCVSMPTETime(from: videoSampleBuffer)
-            else { return nil }
+        else { return nil }
         
         // Evaluate TimeCode Quanta
         var quanta: UInt32 = 30
@@ -79,7 +79,7 @@ class CaptureTimecodeHelper: NSObject {
         
         // Prepare Data Buffer for new SampleBuffer
         guard let dataBuffer = prepareTimeCodeDataBuffer(smpteTime, sizes, quanta, tcType)
-            else { return nil }
+        else { return nil }
         
         /* ============================================ */
         

--- a/Sources/DLABCapture/VideoSampleBufferHelper.swift
+++ b/Sources/DLABCapture/VideoSampleBufferHelper.swift
@@ -36,29 +36,25 @@ internal final class VideoSampleBufferHelper: @unchecked Sendable {
     private let poolLock = UnfairLockBox()
     private var pixelBufferPoolStorage: CVPixelBufferPool? = nil
     
-    private func resolvePixelBufferPool(with dict: CFDictionary) -> CVPixelBufferPool? {
-        poolLock.withLock {
-            let pool = pixelBufferPoolStorage
-            guard let pool, let pbAttr = CVPixelBufferPoolGetPixelBufferAttributes(pool) else {
-                return nil
-            }
-            let typeOK = equalCFNumberInDictionary(dict, pbAttr, kCVPixelBufferPixelFormatTypeKey)
-            let widthOK = equalCFNumberInDictionary(dict, pbAttr, kCVPixelBufferWidthKey)
-            let heightOK = equalCFNumberInDictionary(dict, pbAttr, kCVPixelBufferHeightKey)
-            let strideOK = equalCFNumberInDictionary(dict, pbAttr, kCVPixelBufferBytesPerRowAlignmentKey)
-            if typeOK && widthOK && heightOK && strideOK {
-                return pool
-            }
-            CVPixelBufferPoolFlush(pool, .excessBuffers)
-            pixelBufferPoolStorage = nil
-            return nil
+    private func matchesPixelBufferPool(_ pool: CVPixelBufferPool, with dict: CFDictionary) -> Bool {
+        guard let pbAttr = CVPixelBufferPoolGetPixelBufferAttributes(pool) else {
+            return false
         }
+        let typeOK = equalCFNumberInDictionary(dict, pbAttr, kCVPixelBufferPixelFormatTypeKey)
+        let widthOK = equalCFNumberInDictionary(dict, pbAttr, kCVPixelBufferWidthKey)
+        let heightOK = equalCFNumberInDictionary(dict, pbAttr, kCVPixelBufferHeightKey)
+        let strideOK = equalCFNumberInDictionary(dict, pbAttr, kCVPixelBufferBytesPerRowAlignmentKey)
+        return typeOK && widthOK && heightOK && strideOK
     }
     
-    private func createPixelBufferPool(with dict: CFDictionary) -> CVPixelBufferPool {
+    private func getOrCreatePixelBufferPool(with dict: CFDictionary) -> CVPixelBufferPool {
         poolLock.withLock {
             if let pool = pixelBufferPoolStorage {
-                return pool
+                if matchesPixelBufferPool(pool, with: dict) {
+                    return pool
+                }
+                CVPixelBufferPoolFlush(pool, .excessBuffers)
+                pixelBufferPoolStorage = nil
             }
             let poolAttr = [kCVPixelBufferPoolMinimumBufferCountKey: 4 as CFNumber] as CFDictionary
             let err = CVPixelBufferPoolCreate(kCFAllocatorDefault, poolAttr, dict, &pixelBufferPoolStorage)
@@ -167,9 +163,7 @@ internal final class VideoSampleBufferHelper: @unchecked Sendable {
             kCVPixelBufferIOSurfacePropertiesKey: [:] as [CFString : Any],
         ] as [CFString : Any] as CFDictionary
         
-        if resolvePixelBufferPool(with: dict) == nil {
-            _ = createPixelBufferPool(with: dict)
-        }
+        _ = getOrCreatePixelBufferPool(with: dict)
         
         pbOut = takePixelBuffer()
         

--- a/Sources/DLABCapture/VideoSampleBufferHelper.swift
+++ b/Sources/DLABCapture/VideoSampleBufferHelper.swift
@@ -33,7 +33,48 @@ internal final class VideoSampleBufferHelper: @unchecked Sendable {
     /* ================================================ */
     
     /// CVPixelBufferPool
-    private var pixelBufferPool :CVPixelBufferPool? = nil
+    private let poolLock = UnfairLockBox()
+    private var pixelBufferPoolStorage: CVPixelBufferPool? = nil
+    
+    private func resolvePixelBufferPool(with dict: CFDictionary) -> CVPixelBufferPool? {
+        poolLock.withLock {
+            let pool = pixelBufferPoolStorage
+            guard let pool, let pbAttr = CVPixelBufferPoolGetPixelBufferAttributes(pool) else {
+                return nil
+            }
+            let typeOK = equalCFNumberInDictionary(dict, pbAttr, kCVPixelBufferPixelFormatTypeKey)
+            let widthOK = equalCFNumberInDictionary(dict, pbAttr, kCVPixelBufferWidthKey)
+            let heightOK = equalCFNumberInDictionary(dict, pbAttr, kCVPixelBufferHeightKey)
+            let strideOK = equalCFNumberInDictionary(dict, pbAttr, kCVPixelBufferBytesPerRowAlignmentKey)
+            if typeOK && widthOK && heightOK && strideOK {
+                return pool
+            }
+            CVPixelBufferPoolFlush(pool, .excessBuffers)
+            pixelBufferPoolStorage = nil
+            return nil
+        }
+    }
+    
+    private func createPixelBufferPool(with dict: CFDictionary) -> CVPixelBufferPool {
+        poolLock.withLock {
+            if let pool = pixelBufferPoolStorage {
+                return pool
+            }
+            let poolAttr = [kCVPixelBufferPoolMinimumBufferCountKey: 4 as CFNumber] as CFDictionary
+            let err = CVPixelBufferPoolCreate(kCFAllocatorDefault, poolAttr, dict, &pixelBufferPoolStorage)
+            precondition(err == kCVReturnSuccess, "ERROR: Failed to create CVPixelBufferPool")
+            return pixelBufferPoolStorage!
+        }
+    }
+    
+    private func takePixelBuffer() -> CVPixelBuffer? {
+        poolLock.withLock {
+            guard let pool = pixelBufferPoolStorage else { return nil }
+            var pbOut: CVPixelBuffer?
+            CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pool, &pbOut)
+            return pbOut
+        }
+    }
     
     /* ================================================ */
     // MARK: - public functions (duplicate sampleBuffer)
@@ -125,27 +166,12 @@ internal final class VideoSampleBufferHelper: @unchecked Sendable {
             kCVPixelBufferBytesPerRowAlignmentKey: alignment as CFNumber,
             kCVPixelBufferIOSurfacePropertiesKey: [:] as [CFString : Any],
         ] as [CFString : Any] as CFDictionary
-        if let pool = pixelBufferPool, let pbAttr = CVPixelBufferPoolGetPixelBufferAttributes(pool) {
-            // Check if pixelBufferPool is compatible or not
-            let typeOK = equalCFNumberInDictionary(dict, pbAttr, kCVPixelBufferPixelFormatTypeKey)
-            let widthOK = equalCFNumberInDictionary(dict, pbAttr, kCVPixelBufferWidthKey)
-            let heightOK = equalCFNumberInDictionary(dict, pbAttr, kCVPixelBufferHeightKey)
-            let strideOK = equalCFNumberInDictionary(dict, pbAttr, kCVPixelBufferBytesPerRowAlignmentKey)
-            if !(typeOK && widthOK && heightOK && strideOK) {
-                CVPixelBufferPoolFlush(pool, .excessBuffers)
-                self.pixelBufferPool = nil
-            }
+        
+        if resolvePixelBufferPool(with: dict) == nil {
+            _ = createPixelBufferPool(with: dict)
         }
-        if pixelBufferPool == nil {
-            let poolAttr = [
-                kCVPixelBufferPoolMinimumBufferCountKey: 4 as CFNumber
-            ] as CFDictionary
-            let err = CVPixelBufferPoolCreate(kCFAllocatorDefault, poolAttr, dict, &pixelBufferPool)
-            precondition(err == kCVReturnSuccess, "ERROR: Failed to create CVPixelBufferPool")
-        }
-        if let pixelBufferPool = pixelBufferPool {
-            CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pixelBufferPool, &pbOut)
-        }
+        
+        pbOut = takePixelBuffer()
         
         if let pbOut = pbOut {
             CVPixelBufferLockBaseAddress(pb, .readOnly)
@@ -300,21 +326,11 @@ internal final class VideoSampleBufferHelper: @unchecked Sendable {
     // MARK: - private functions (sampleBuffer properties)
     /* ================================================ */
     
-    //
-    private var useCast :Bool = true
-    
     /// CFObject to UnsafeRawPointer conversion
     /// - Parameter obj: AnyObject to convert
     /// - Returns: UnsafeRawPointer
     private func toOpaque(_ obj :AnyObject) -> UnsafeRawPointer {
-        if useCast {
-            let ptr = unsafeBitCast(obj, to: UnsafeRawPointer.self)
-            return ptr
-        } else {
-            let mutablePtr :UnsafeMutableRawPointer = Unmanaged.passUnretained(obj).toOpaque()
-            let ptr :UnsafeRawPointer = UnsafeRawPointer(mutablePtr)
-            return ptr
-        }
+        UnsafeRawPointer(Unmanaged.passUnretained(obj).toOpaque())
     }
     
     /// UnsafeRawPointer to CFObject conversion

--- a/Sources/DLABCapture/VideoSampleBufferHelper.swift
+++ b/Sources/DLABCapture/VideoSampleBufferHelper.swift
@@ -47,28 +47,36 @@ internal final class VideoSampleBufferHelper: @unchecked Sendable {
         return typeOK && widthOK && heightOK && strideOK
     }
     
+    private func getOrCreatePixelBufferPoolLocked(with dict: CFDictionary) -> CVPixelBufferPool {
+        if let pool = pixelBufferPoolStorage {
+            if matchesPixelBufferPool(pool, with: dict) {
+                return pool
+            }
+            CVPixelBufferPoolFlush(pool, .excessBuffers)
+            pixelBufferPoolStorage = nil
+        }
+        let poolAttr = [kCVPixelBufferPoolMinimumBufferCountKey: 4 as CFNumber] as CFDictionary
+        let err = CVPixelBufferPoolCreate(kCFAllocatorDefault, poolAttr, dict, &pixelBufferPoolStorage)
+        precondition(err == kCVReturnSuccess, "ERROR: Failed to create CVPixelBufferPool")
+        return pixelBufferPoolStorage!
+    }
+
     private func getOrCreatePixelBufferPool(with dict: CFDictionary) -> CVPixelBufferPool {
         poolLock.withLock {
-            if let pool = pixelBufferPoolStorage {
-                if matchesPixelBufferPool(pool, with: dict) {
-                    return pool
-                }
-                CVPixelBufferPoolFlush(pool, .excessBuffers)
-                pixelBufferPoolStorage = nil
-            }
-            let poolAttr = [kCVPixelBufferPoolMinimumBufferCountKey: 4 as CFNumber] as CFDictionary
-            let err = CVPixelBufferPoolCreate(kCFAllocatorDefault, poolAttr, dict, &pixelBufferPoolStorage)
-            precondition(err == kCVReturnSuccess, "ERROR: Failed to create CVPixelBufferPool")
-            return pixelBufferPoolStorage!
+            getOrCreatePixelBufferPoolLocked(with: dict)
         }
     }
     
-    private func takePixelBuffer() -> CVPixelBuffer? {
+    private func takePixelBuffer(from pool: CVPixelBufferPool) -> CVPixelBuffer? {
+        var pbOut: CVPixelBuffer?
+        CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pool, &pbOut)
+        return pbOut
+    }
+
+    private func takePixelBuffer(matching dict: CFDictionary) -> CVPixelBuffer? {
         poolLock.withLock {
-            guard let pool = pixelBufferPoolStorage else { return nil }
-            var pbOut: CVPixelBuffer?
-            CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pool, &pbOut)
-            return pbOut
+            let pool = getOrCreatePixelBufferPoolLocked(with: dict)
+            return takePixelBuffer(from: pool)
         }
     }
     
@@ -163,9 +171,7 @@ internal final class VideoSampleBufferHelper: @unchecked Sendable {
             kCVPixelBufferIOSurfacePropertiesKey: [:] as [CFString : Any],
         ] as [CFString : Any] as CFDictionary
         
-        _ = getOrCreatePixelBufferPool(with: dict)
-        
-        pbOut = takePixelBuffer()
+        pbOut = takePixelBuffer(matching: dict)
         
         if let pbOut = pbOut {
             CVPixelBufferLockBaseAddress(pb, .readOnly)

--- a/Sources/DLABCapture/VideoSampleBufferHelper.swift
+++ b/Sources/DLABCapture/VideoSampleBufferHelper.swift
@@ -60,7 +60,7 @@ internal final class VideoSampleBufferHelper: @unchecked Sendable {
         precondition(err == kCVReturnSuccess, "ERROR: Failed to create CVPixelBufferPool")
         return pixelBufferPoolStorage!
     }
-
+    
     private func getOrCreatePixelBufferPool(with dict: CFDictionary) -> CVPixelBufferPool {
         poolLock.withLock {
             getOrCreatePixelBufferPoolLocked(with: dict)
@@ -72,7 +72,7 @@ internal final class VideoSampleBufferHelper: @unchecked Sendable {
         CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pool, &pbOut)
         return pbOut
     }
-
+    
     private func takePixelBuffer(matching dict: CFDictionary) -> CVPixelBuffer? {
         poolLock.withLock {
             let pool = getOrCreatePixelBufferPoolLocked(with: dict)

--- a/Sources/DLABridging/src/DLABAudioSetting.mm
+++ b/Sources/DLABridging/src/DLABAudioSetting.mm
@@ -96,7 +96,7 @@
          code:(NSInteger)result
            to:(NSError**)error;
 {
-    return DLABAssignError(error, description, failureReason, (NSInteger)result);
+    return DLABPostError(error, description, failureReason, result);
 }
 
 /* =================================================================================== */

--- a/Sources/DLABridging/src/DLABBridgingSupport.h
+++ b/Sources/DLABridging/src/DLABBridgingSupport.h
@@ -34,6 +34,14 @@ NS_INLINE BOOL DLABAssignError(NSError * _Nullable * _Nullable error,
     return NO;
 }
 
+NS_INLINE BOOL DLABPostError(NSError * _Nullable * _Nullable error,
+                             NSString * _Nullable description,
+                             NSString * _Nullable failureReason,
+                             NSInteger code)
+{
+    return DLABAssignError(error, description, failureReason, code);
+}
+
 NS_INLINE void DLABRaiseUnavailableInit(id _Nonnull selfObject, SEL _Nonnull requiredSelector)
 {
     NSString *classString = NSStringFromClass([selfObject class]);

--- a/Sources/DLABridging/src/DLABDeckControl.mm
+++ b/Sources/DLABridging/src/DLABDeckControl.mm
@@ -158,7 +158,7 @@ NS_INLINE BOOL DLABPerformDeckCommandWithStatusError(DLABDeckControl *self,
          code:(NSInteger)result
            to:(NSError**)error;
 {
-    return DLABAssignError(error, description, failureReason, (NSInteger)result);
+    return DLABPostError(error, description, failureReason, result);
 }
 
 /* =================================================================================== */

--- a/Sources/DLABridging/src/DLABDevice+Input.mm
+++ b/Sources/DLABridging/src/DLABDevice+Input.mm
@@ -247,7 +247,7 @@ NS_INLINE NSNumber * DLABInputUInt32Value(DLABDevice *self,
 /* =================================================================================== */
 
 NS_INLINE BOOL copyBufferDLtoCV(DLABDevice* self, IDeckLinkVideoFrame* videoFrame, CVPixelBufferRef pixelBuffer) {
-    assert(videoFrame && pixelBuffer);
+    if (!videoFrame || !pixelBuffer) return FALSE;
     
     BOOL pre1403 = [DLABVersionChecker checkPre1403];
     
@@ -291,12 +291,14 @@ NS_INLINE BOOL copyBufferDLtoCV(DLABDevice* self, IDeckLinkVideoFrame* videoFram
             } else {
                 pixelSize = pixelSizeForCV(pixelBuffer);
             }
-            assert(pixelSize > 0);
-            
-            vImage_Error convErr = kvImageNoError;
-            convErr = vImageCopyBuffer(&sourceBuffer, &targetBuffer,
-                                       pixelSize, kvImageNoFlags);
-            result = (convErr == kvImageNoError);
+            if (pixelSize == 0) {
+                result = false;
+            } else {
+                vImage_Error convErr = kvImageNoError;
+                convErr = vImageCopyBuffer(&sourceBuffer, &targetBuffer,
+                                           pixelSize, kvImageNoFlags);
+                result = (convErr == kvImageNoError);
+            }
         }
         CVPixelBufferUnlockBaseAddress(pixelBuffer, 0);
     }
@@ -309,7 +311,7 @@ NS_INLINE BOOL copyBufferDLtoCV(DLABDevice* self, IDeckLinkVideoFrame* videoFram
 }
 
 NS_INLINE BOOL copyPlaneDLtoCV(DLABDevice* self, IDeckLinkVideoInputFrame* videoFrame, CVPixelBufferRef pixelBuffer) {
-    assert(videoFrame && pixelBuffer);
+    if (!videoFrame || !pixelBuffer) return FALSE;
     
     BOOL pre1403 = [DLABVersionChecker checkPre1403];
     
@@ -372,7 +374,7 @@ NS_INLINE BOOL copyPlaneDLtoCV(DLABDevice* self, IDeckLinkVideoInputFrame* video
     
     BOOL ready = false;
     OSType cvPixelFormat = self.inputVideoSetting.cvPixelFormatType;
-    assert(cvPixelFormat);
+    if (!cvPixelFormat) return NULL;
     
     // Check pool, and create if required
     CVPixelBufferPoolRef pool = self.inputPixelBufferPool;
@@ -629,7 +631,7 @@ NS_INLINE BOOL copyPlaneDLtoCV(DLABDevice* self, IDeckLinkVideoInputFrame* video
 }
 
 static DLABTimecodeSetting* createTimecodeSetting(IDeckLinkVideoInputFrame* videoFrame, BMDTimecodeFormat format) {
-    assert(videoFrame && format);
+    if (!videoFrame || !format) return nil;
     
     HRESULT result = E_FAIL;
     

--- a/Sources/DLABridging/src/DLABDevice+Internal.h
+++ b/Sources/DLABridging/src/DLABDevice+Internal.h
@@ -350,6 +350,21 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, assign) BOOL prefsChangeNotificationSubscribed;
 
+/**
+ Tracks whether IDeckLinkInput currently has the callback installed.
+ */
+@property (nonatomic, assign) BOOL inputCallbackRegistered;
+
+/**
+ Tracks whether IDeckLinkOutput currently has the callback installed.
+ */
+@property (nonatomic, assign) BOOL outputCallbackRegistered;
+
+/**
+ Tracks whether IDeckLinkProfileManager currently has the callback installed.
+ */
+@property (nonatomic, assign) BOOL profileCallbackRegistered;
+
 //
 
 /**

--- a/Sources/DLABridging/src/DLABDevice+Internal.h
+++ b/Sources/DLABridging/src/DLABDevice+Internal.h
@@ -10,6 +10,7 @@
 
 #import <DLABDevice.h>
 #import <DLABVersionChecker.h>
+#import <DLABVideoFramePool.h>
 #import <DeckLinkAPI.h>
 
 #import <DeckLinkAPI_v15_3_1.h>
@@ -42,8 +43,6 @@
 #import <DLABFrameMetadata+Internal.h>
 #import <DLABVideoConverter.h>
 #import <DLABDeckControl+Internal.h>
-
-const int maxOutputVideoFrameCount = 8;
 
 NS_INLINE IDeckLinkScreenPreviewCallback * _Nullable DLABCreateScreenPreviewCallback(NSView * _Nonnull parentView)
 {
@@ -304,17 +303,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, assign, readonly) void* delegateQueueKey;
 
-// NSMutableSet* - OutputVideoFramePool management
+// DLABVideoFramePool - OutputVideoFramePool management
 
 /**
  OutputVideoFramePool management.
  */
-@property (nonatomic, strong, readonly) NSMutableSet* outputVideoFrameSet;
-
-/**
- OutputVideoFramePool management.
- */
-@property (nonatomic, strong, readonly) NSMutableSet* outputVideoFrameIdleSet;
+@property (nonatomic, strong, readonly) DLABVideoFramePool* outputVideoFramePool;
 
 /* =================================================================================== */
 
@@ -398,33 +392,6 @@ NS_ASSUME_NONNULL_BEGIN
 /* =================================================================================== */
 // MARK: private method
 /* =================================================================================== */
-
-/**
- Check output VideoFrame pool and expand if required.
- 
- @return YES if no error, NO if failed
- */
-- (BOOL) prepareOutputVideoFramePool;
-
-/**
- Clean up all output VideoFrame in pool
- */
-- (void) freeOutputVideoFramePool;
-
-/**
- Reserve output VideoFrame and take it out from output VideoFrame pool
- 
- @return IDeckLinkMutableVideoFrame or null if failed.
- */
-- (nullable IDeckLinkMutableVideoFrame*) reserveOutputVideoFrame;
-
-/**
- Release output VideoFrame and return it to output VideoFrame pool
- 
- @param outFrame IDeckLinkMutableVideoFrame
- @return YES if no error, NO if failed
- */
-- (BOOL) releaseOutputVideoFrame:(IDeckLinkMutableVideoFrame*)outFrame;
 
 /**
  Prepare output VideoFrame from PixelBuffer

--- a/Sources/DLABridging/src/DLABDevice+Internal.h
+++ b/Sources/DLABridging/src/DLABDevice+Internal.h
@@ -340,6 +340,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, assign) BOOL needsInputVideoConfigurationRefresh;
 
+/**
+ Tracks whether bmdStatusChanged is currently subscribed.
+ */
+@property (nonatomic, assign) BOOL statusChangeNotificationSubscribed;
+
+/**
+ Tracks whether bmdPreferencesChanged is currently subscribed.
+ */
+@property (nonatomic, assign) BOOL prefsChangeNotificationSubscribed;
+
 //
 
 /**

--- a/Sources/DLABridging/src/DLABDevice+Output.mm
+++ b/Sources/DLABridging/src/DLABDevice+Output.mm
@@ -112,6 +112,12 @@ NS_INLINE NSNumber * DLABOutputBoolValue(DLABDevice *self,
     return nil;
 }
 
+NS_INLINE void DLABResetOutputVideoResources(DLABDevice *self)
+{
+    [self.outputVideoFramePool freeFrames];
+    self.outputVideoConverter = nil;
+}
+
 /* =================================================================================== */
 // MARK: - output (internal)
 /* =================================================================================== */
@@ -857,6 +863,7 @@ NS_INLINE BOOL copyPlaneCVtoDL(DLABDevice* self, CVPixelBufferRef pixelBuffer, I
         return output->EnableVideoOutput(displayMode, outputFlag);
     });
     if (succeeded) {
+        DLABResetOutputVideoResources(self);
         self.outputVideoSettingW = setting;
     } else {
         self.outputVideoSettingW = nil;
@@ -890,6 +897,7 @@ NS_INLINE BOOL copyPlaneCVtoDL(DLABDevice* self, CVPixelBufferRef pixelBuffer, I
         return output->DisableVideoOutput();
     });
     if (succeeded) {
+        DLABResetOutputVideoResources(self);
         self.outputVideoSettingW = nil;
     }
     return succeeded;

--- a/Sources/DLABridging/src/DLABDevice+Output.mm
+++ b/Sources/DLABridging/src/DLABDevice+Output.mm
@@ -10,6 +10,7 @@
 
 #import <DLABDevice+Internal.h>
 #import <DLABBridgingSupport.h>
+#import <DLABVideoFramePool.h>
 #import <DLABQueryInterfaceAny.h>
 #import <DLABVideoBufferSupport.h>
 
@@ -135,7 +136,7 @@ NS_INLINE BMDAncillaryDataSpace DLABBMDAncillaryDataSpaceFromPublic(DLABAncillar
     // TODO eval GetFrameCompletionReferenceTimestamp() here
     
     // free output frame
-    [self releaseOutputVideoFrame:(IDeckLinkMutableVideoFrame *)frame];
+    [self.outputVideoFramePool releaseFrame:(IDeckLinkMutableVideoFrame *)frame];
     
     // delegate can schedule next frame here
     __weak typeof(self) wself = self;
@@ -168,102 +169,6 @@ NS_INLINE BMDAncillaryDataSpace DLABBMDAncillaryDataSpaceFromPublic(DLABAncillar
 }
 
 /* =================================================================================== */
-// MARK: Manage output VideoFrame pool
-/* =================================================================================== */
-
-- (BOOL) prepareOutputVideoFramePool
-{
-    BOOL ret = NO;
-    HRESULT result = E_FAIL;
-    DLABVideoSetting* setting = self.outputVideoSetting;
-    IDeckLinkOutput* output = self.deckLinkOutput;
-    if (output && setting) {
-        @synchronized (self) {
-            // Set initial pool size as 4 frames
-            BOOL initialSetup = (self.outputVideoFrameSet.count == 0);
-            int expandingUnit = initialSetup ? 4 : 2;
-            
-            BOOL needsExpansion = (self.outputVideoFrameIdleSet.count == 0);
-            if (needsExpansion) {
-                // Get frame properties
-                int32_t width = (int32_t)setting.width;
-                int32_t height = (int32_t)setting.height;
-                int32_t rowBytes = (int32_t)setting.rowBytes;
-                BMDPixelFormat pixelFormat = setting.pixelFormat;
-                BMDFrameFlags flags = setting.outputFlag;
-                
-                // Try expanding the OutputVideoFramePool
-                for (int i = 0; i < expandingUnit; i++) {
-                    // Check if pool size is at maximum value
-                    BOOL poolIsFull = (self.outputVideoFrameSet.count >= maxOutputVideoFrameCount);
-                    if (poolIsFull) break;
-                    
-                    // Create new output videoFrame object
-                    IDeckLinkMutableVideoFrame *outFrame = NULL;
-                    result = output->CreateVideoFrame(width, height, rowBytes,
-                                                      pixelFormat, flags, &outFrame);
-                    if (result) break;
-                    
-                    // register outputVideoFrame into the pool
-                    NSValue* ptrValue = [NSValue valueWithPointer:(void*)outFrame];
-                    [self.outputVideoFrameSet addObject:ptrValue];
-                    [self.outputVideoFrameIdleSet addObject:ptrValue];
-                }
-            }
-            ret = (self.outputVideoFrameIdleSet.count > 0);
-        }
-    }
-    return ret;
-}
-
-- (void) freeOutputVideoFramePool
-{
-    @synchronized (self) {
-        // Release all outputVideoFrame objects
-        for (NSValue *ptrValue in self.outputVideoFrameSet) {
-            IDeckLinkMutableVideoFrame *outFrame = (IDeckLinkMutableVideoFrame*)ptrValue.pointerValue;
-            if (outFrame) {
-                outFrame->Release();
-            }
-        }
-        
-        // unregister all of outputVideoFrame in the pool
-        [self.outputVideoFrameIdleSet removeAllObjects];
-        [self.outputVideoFrameSet removeAllObjects];
-    }
-}
-
-- (IDeckLinkMutableVideoFrame*) reserveOutputVideoFrame
-{
-    // Check if all are in use (and try to expand the pool)
-    [self prepareOutputVideoFramePool];
-    
-    IDeckLinkMutableVideoFrame *outFrame = NULL;
-    @synchronized (self) {
-        NSValue* ptrValue = [self.outputVideoFrameIdleSet anyObject];
-        if (ptrValue) {
-            [self.outputVideoFrameIdleSet removeObject:ptrValue];
-            outFrame = (IDeckLinkMutableVideoFrame*)ptrValue.pointerValue;
-        }
-    }
-    
-    return outFrame;
-}
-
-- (BOOL) releaseOutputVideoFrame:(IDeckLinkMutableVideoFrame*)outFrame
-{
-    BOOL result = NO;
-    @synchronized (self) {
-        NSValue* ptrValue = [NSValue valueWithPointer:(void*)outFrame];
-        NSValue* orgValue = [self.outputVideoFrameSet member:ptrValue];
-        if (orgValue) {
-            [self.outputVideoFrameIdleSet addObject:orgValue];
-            result = YES;
-        }
-    }
-    return result;
-}
-
 /* =================================================================================== */
 // MARK: Process Output videoFrame/timecode
 /* =================================================================================== */
@@ -399,7 +304,8 @@ NS_INLINE BOOL copyPlaneCVtoDL(DLABDevice* self, CVPixelBufferRef pixelBuffer, I
     if (!cvPixelFormat) return NULL;
     
     // take out free output frame from frame pool
-    IDeckLinkMutableVideoFrame* videoFrame = [self reserveOutputVideoFrame];
+    [self.outputVideoFramePool prepareWithOutput:self.deckLinkOutput setting:self.outputVideoSetting];
+    IDeckLinkMutableVideoFrame* videoFrame = [self.outputVideoFramePool reserveFrame];
     if (videoFrame) {
         // Simply check if width, height are same
         size_t pbWidth = CVPixelBufferGetWidth(pixelBuffer);
@@ -434,7 +340,7 @@ NS_INLINE BOOL copyPlaneCVtoDL(DLABDevice* self, CVPixelBufferRef pixelBuffer, I
         return videoFrame;
     } else {
         if (videoFrame)
-            [self releaseOutputVideoFrame:videoFrame];
+            [self.outputVideoFramePool releaseFrame:videoFrame];
         return NULL;
     }
 }
@@ -1225,7 +1131,7 @@ static DLABFrameMetadata * processCallbacks(DLABDevice *self, IDeckLinkMutableVi
         result = output->DisplayVideoFrameSync(outFrame);
         
         // free output frame
-        [self releaseOutputVideoFrame:outFrame];
+        [self.outputVideoFramePool releaseFrame:outFrame];
     } else {
         [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
             reason:@"DLABDevice - outputVideoFrameWithPixelBuffer: failed."
@@ -1238,7 +1144,7 @@ static DLABFrameMetadata * processCallbacks(DLABDevice *self, IDeckLinkMutableVi
         return YES;
     } else {
         if (outFrame) {
-            [self releaseOutputVideoFrame:outFrame];
+            [self.outputVideoFramePool releaseFrame:outFrame];
         }
         
         [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
@@ -1291,7 +1197,7 @@ static DLABFrameMetadata * processCallbacks(DLABDevice *self, IDeckLinkMutableVi
         return YES;
     } else {
         if (outFrame) {
-            [self releaseOutputVideoFrame:outFrame];
+            [self.outputVideoFramePool releaseFrame:outFrame];
         }
         
         [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
@@ -1390,7 +1296,7 @@ static DLABFrameMetadata * processCallbacks(DLABDevice *self, IDeckLinkMutableVi
         return YES;
     } else {
         if (outFrame) {
-            [self releaseOutputVideoFrame:outFrame];
+            [self.outputVideoFramePool releaseFrame:outFrame];
         }
         
         [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]

--- a/Sources/DLABridging/src/DLABDevice+Output.mm
+++ b/Sources/DLABridging/src/DLABDevice+Output.mm
@@ -269,7 +269,7 @@ NS_INLINE BMDAncillaryDataSpace DLABBMDAncillaryDataSpaceFromPublic(DLABAncillar
 /* =================================================================================== */
 
 NS_INLINE BOOL copyBufferCVtoDL(DLABDevice* self, CVPixelBufferRef pixelBuffer, IDeckLinkMutableVideoFrame* videoFrame) {
-    assert(pixelBuffer && videoFrame);
+    if (!pixelBuffer || !videoFrame) return FALSE;
     
     BOOL pre1403 = [DLABVersionChecker checkPre1403];
     
@@ -313,12 +313,14 @@ NS_INLINE BOOL copyBufferCVtoDL(DLABDevice* self, CVPixelBufferRef pixelBuffer, 
             } else {
                 pixelSize = pixelSizeForCV(pixelBuffer);
             }
-            assert(pixelSize > 0);
-            
-            vImage_Error convErr = kvImageNoError;
-            convErr = vImageCopyBuffer(&sourceBuffer, &targetBuffer,
-                                       pixelSize, kvImageNoFlags);
-            result = (convErr == kvImageNoError);
+            if (pixelSize == 0) {
+                result = false;
+            } else {
+                vImage_Error convErr = kvImageNoError;
+                convErr = vImageCopyBuffer(&sourceBuffer, &targetBuffer,
+                                           pixelSize, kvImageNoFlags);
+                result = (convErr == kvImageNoError);
+            }
         }
         CVPixelBufferUnlockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
     }
@@ -331,7 +333,7 @@ NS_INLINE BOOL copyBufferCVtoDL(DLABDevice* self, CVPixelBufferRef pixelBuffer, 
 }
 
 NS_INLINE BOOL copyPlaneCVtoDL(DLABDevice* self, CVPixelBufferRef pixelBuffer, IDeckLinkMutableVideoFrame* videoFrame) {
-    assert(pixelBuffer && videoFrame);
+    if (!pixelBuffer || !videoFrame) return FALSE;
     
     BOOL pre1403 = [DLABVersionChecker checkPre1403];
     
@@ -394,7 +396,7 @@ NS_INLINE BOOL copyPlaneCVtoDL(DLABDevice* self, CVPixelBufferRef pixelBuffer, I
     
     BOOL ready = false;
     OSType cvPixelFormat = self.outputVideoSetting.cvPixelFormatType;
-    assert(cvPixelFormat);
+    if (!cvPixelFormat) return NULL;
     
     // take out free output frame from frame pool
     IDeckLinkMutableVideoFrame* videoFrame = [self reserveOutputVideoFrame];

--- a/Sources/DLABridging/src/DLABDevice.mm
+++ b/Sources/DLABridging/src/DLABDevice.mm
@@ -321,12 +321,16 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
         _profileCallback = NULL;
     }
     if (_prefsChangeCallback) {
-        [self subscribePrefsChangeNotification:NO];
+        if (_prefsChangeNotificationSubscribed) {
+            [self subscribePrefsChangeNotification:NO];
+        }
         _prefsChangeCallback->Release();
         _prefsChangeCallback = NULL;
     }
     if (_statusChangeCallback) {
-        [self subscribeStatusChangeNotification:NO];
+        if (_statusChangeNotificationSubscribed) {
+            [self subscribeStatusChangeNotification:NO];
+        }
         _statusChangeCallback->Release();
         _statusChangeCallback = NULL;
     }
@@ -507,6 +511,8 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
 @synthesize inputPreviewCallback = _inputPreviewCallback;
 
 @synthesize needsInputVideoConfigurationRefresh = _needsInputVideoConfigurationRefresh;
+@synthesize statusChangeNotificationSubscribed = _statusChangeNotificationSubscribed;
+@synthesize prefsChangeNotificationSubscribed = _prefsChangeNotificationSubscribed;
 @synthesize inputVideoConverter = _inputVideoConverter;
 @synthesize outputVideoConverter = _outputVideoConverter;
 
@@ -684,11 +690,15 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
         result = notification->Subscribe(bmdStatusChanged, callback);
         if (result) {
             NSLog(@"ERROR: IDeckLinkNotification::Subscribe failed.");
+        } else {
+            self.statusChangeNotificationSubscribed = YES;
         }
     } else {
         result = notification->Unsubscribe(bmdStatusChanged, callback);
         if (result) {
             NSLog(@"ERROR: IDeckLinkNotification::Unsubscribe failed.");
+        } else {
+            self.statusChangeNotificationSubscribed = NO;
         }
     }
     return (result == S_OK);
@@ -705,11 +715,15 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
         result = notification->Subscribe(bmdPreferencesChanged, callback);
         if (result) {
             NSLog(@"ERROR: IDeckLinkNotification::Subscribe failed.");
+        } else {
+            self.prefsChangeNotificationSubscribed = YES;
         }
     } else {
         result = notification->Unsubscribe(bmdPreferencesChanged, callback);
         if (result) {
             NSLog(@"ERROR: IDeckLinkNotification::Unsubscribe failed.");
+        } else {
+            self.prefsChangeNotificationSubscribed = NO;
         }
     }
     return (result == S_OK);

--- a/Sources/DLABridging/src/DLABDevice.mm
+++ b/Sources/DLABridging/src/DLABDevice.mm
@@ -806,92 +806,84 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
 // MARK: - (Public) - property setter
 /* =================================================================================== */
 
+- (void) updateSubscriptionFrom:(id)oldValue
+                           to:(id)newValue
+                        block:(BOOL(^)(BOOL))subscribeBlock
+{
+    if (oldValue) {
+        subscribeBlock(NO);
+    }
+    if (newValue) {
+        subscribeBlock(YES);
+    }
+}
+
 - (void) setOutputDelegate:(id<DLABOutputPlaybackDelegate>)newDelegate
 {
     if (_outputDelegate == newDelegate) return;
-    if (_outputDelegate) {
-        // Unsubscribe request from current delegate
-        _outputDelegate = nil;
-        
-        [self subscribeOutput:NO];
-    }
+    id old = _outputDelegate;
+    _outputDelegate = nil;
     if (newDelegate) {
-        // Subscribe request from new delegate
         _outputDelegate = newDelegate;
-        
-        [self subscribeOutput:YES];
     }
+    [self updateSubscriptionFrom:old
+                              to:newDelegate
+                           block:^BOOL(BOOL flag) { return [self subscribeOutput:flag]; }];
 }
 
 - (void) setInputDelegate:(id<DLABInputCaptureDelegate>)newDelegate
 {
     if (_inputDelegate == newDelegate) return;
-    if (_inputDelegate) {
-        // Unsubscribe request from current delegate
-        _inputDelegate = nil;
-        
-        [self subscribeInput:NO];
-    }
+    id old = _inputDelegate;
+    _inputDelegate = nil;
     if (newDelegate) {
-        // Subscribe request from new delegate
         _inputDelegate = newDelegate;
-        
-        [self subscribeInput:YES];
     }
+    [self updateSubscriptionFrom:old
+                              to:newDelegate
+                           block:^BOOL(BOOL flag) { return [self subscribeInput:flag]; }];
 }
 
 // public DLABStatusChangeDelegate
 - (void) setStatusDelegate:(id<DLABStatusChangeDelegate>)newDelegate
 {
     if (_statusDelegate == newDelegate) return;
-    if (_statusDelegate) {
-        // Unsubscribe request from current delegate
-        _statusDelegate = nil;
-        
-        [self subscribeStatusChangeNotification:NO];
-    }
+    id old = _statusDelegate;
+    _statusDelegate = nil;
     if (newDelegate) {
-        // Subscribe request from new delegate
         _statusDelegate = newDelegate;
-        
-        [self subscribeStatusChangeNotification:YES];
     }
+    [self updateSubscriptionFrom:old
+                              to:newDelegate
+                           block:^BOOL(BOOL flag) { return [self subscribeStatusChangeNotification:flag]; }];
 }
 
 // public DLABPrefsChangeDelegate
 - (void) setPrefsDelegate:(id<DLABPrefsChangeDelegate>)newDelegate
 {
     if (_prefsDelegate == newDelegate) return;
-    if (_prefsDelegate) {
-        // Unsubscribe request from current delegate
-        _prefsDelegate = nil;
-        
-        [self subscribePrefsChangeNotification:NO];
-    }
+    id old = _prefsDelegate;
+    _prefsDelegate = nil;
     if (newDelegate) {
-        // Subscribe request from new delegate
         _prefsDelegate = newDelegate;
-        
-        [self subscribePrefsChangeNotification:YES];
     }
+    [self updateSubscriptionFrom:old
+                              to:newDelegate
+                           block:^BOOL(BOOL flag) { return [self subscribePrefsChangeNotification:flag]; }];
 }
 
 // public DLABProfileChangeDelegate
 - (void) setProfileDelegate:(id<DLABProfileChangeDelegate>)newDelegate
 {
     if (_profileDelegate == newDelegate) return;
-    if (_profileDelegate) {
-        // Unsubscribe request from current delegate
-        _profileDelegate = nil;
-        
-        [self subscribeProfileChange:NO];
-    }
+    id old = _profileDelegate;
+    _profileDelegate = nil;
     if (newDelegate) {
-        // Subscribe request from new delegate
         _profileDelegate = newDelegate;
-        
-        [self subscribeProfileChange:YES];
     }
+    [self updateSubscriptionFrom:old
+                              to:newDelegate
+                           block:^BOOL(BOOL flag) { return [self subscribeProfileChange:flag]; }];
 }
 
 /* =================================================================================== */

--- a/Sources/DLABridging/src/DLABDevice.mm
+++ b/Sources/DLABridging/src/DLABDevice.mm
@@ -13,6 +13,22 @@
 #import <DLABQueryInterfaceAny.h>
 #import <DLABVersionChecker.h>
 
+#if DEBUG
+#define DLABShutdownCallbackAssert(condition, message) NSCAssert((condition), (message))
+#else
+#define DLABShutdownCallbackAssert(condition, message) do { (void)(condition); } while (0)
+#endif
+
+NS_INLINE void DLABAssertOrphanedCallback(BOOL released,
+                                          NSString * _Nonnull callbackName,
+                                          NSString * _Nonnull operationName)
+{
+    DLABShutdownCallbackAssert(released,
+                               ([NSString stringWithFormat:@"%@ failed during shutdown; retaining %@ to avoid releasing a callback still owned by DeckLink.",
+                                 operationName,
+                                 callbackName]));
+}
+
 const char* kCaptureQueue = "DLABDevice.captureQueue";
 const char* kPlaybackQueue = "DLABDevice.playbackQueue";
 const char* kDelegateQueue = "DLABDevice.delegateQueue";
@@ -316,15 +332,26 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
         _inputPreviewCallback = NULL;
     }
     if (_profileCallback) {
-        [self subscribeProfileChange:NO];
-        _profileCallback->Release();
-        _profileCallback = NULL;
+        BOOL canReleaseProfileCallback = YES;
+        if (_profileCallbackRegistered) {
+            canReleaseProfileCallback = [self subscribeProfileChange:NO];
+        }
+        DLABAssertOrphanedCallback(canReleaseProfileCallback,
+                                   @"_profileCallback",
+                                   @"IDeckLinkProfileManager::SetCallback(NULL)");
+        if (canReleaseProfileCallback) {
+            _profileCallback->Release();
+            _profileCallback = NULL;
+        }
     }
     if (_prefsChangeCallback) {
         BOOL canReleasePrefsCallback = YES;
         if (_prefsChangeNotificationSubscribed) {
             canReleasePrefsCallback = [self subscribePrefsChangeNotification:NO];
         }
+        DLABAssertOrphanedCallback(canReleasePrefsCallback,
+                                   @"_prefsChangeCallback",
+                                   @"IDeckLinkNotification::Unsubscribe(bmdPreferencesChanged)");
         if (canReleasePrefsCallback) {
             _prefsChangeCallback->Release();
             _prefsChangeCallback = NULL;
@@ -335,20 +362,39 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
         if (_statusChangeNotificationSubscribed) {
             canReleaseStatusCallback = [self subscribeStatusChangeNotification:NO];
         }
+        DLABAssertOrphanedCallback(canReleaseStatusCallback,
+                                   @"_statusChangeCallback",
+                                   @"IDeckLinkNotification::Unsubscribe(bmdStatusChanged)");
         if (canReleaseStatusCallback) {
             _statusChangeCallback->Release();
             _statusChangeCallback = NULL;
         }
     }
     if (_outputCallback) {
-        [self subscribeOutput:NO];
-        _outputCallback->Release();
-        _outputCallback = NULL;
+        BOOL canReleaseOutputCallback = YES;
+        if (_outputCallbackRegistered) {
+            canReleaseOutputCallback = [self subscribeOutput:NO];
+        }
+        DLABAssertOrphanedCallback(canReleaseOutputCallback,
+                                   @"_outputCallback",
+                                   @"IDeckLinkOutput::SetScheduledFrameCompletionCallback(NULL)");
+        if (canReleaseOutputCallback) {
+            _outputCallback->Release();
+            _outputCallback = NULL;
+        }
     }
     if (_inputCallback) {
-        [self subscribeInput:NO];
-        _inputCallback->Release();
-        _inputCallback = NULL;
+        BOOL canReleaseInputCallback = YES;
+        if (_inputCallbackRegistered) {
+            canReleaseInputCallback = [self subscribeInput:NO];
+        }
+        DLABAssertOrphanedCallback(canReleaseInputCallback,
+                                   @"_inputCallback",
+                                   @"IDeckLinkInput::SetCallback(NULL)");
+        if (canReleaseInputCallback) {
+            _inputCallback->Release();
+            _inputCallback = NULL;
+        }
     }
     
     if (_deckLinkOutput) {
@@ -519,6 +565,9 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
 @synthesize needsInputVideoConfigurationRefresh = _needsInputVideoConfigurationRefresh;
 @synthesize statusChangeNotificationSubscribed = _statusChangeNotificationSubscribed;
 @synthesize prefsChangeNotificationSubscribed = _prefsChangeNotificationSubscribed;
+@synthesize inputCallbackRegistered = _inputCallbackRegistered;
+@synthesize outputCallbackRegistered = _outputCallbackRegistered;
+@synthesize profileCallbackRegistered = _profileCallbackRegistered;
 @synthesize inputVideoConverter = _inputVideoConverter;
 @synthesize outputVideoConverter = _outputVideoConverter;
 
@@ -654,11 +703,15 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
         result = input->SetCallback(callback);
         if (result) {
             NSLog(@"ERROR: IDeckLinkInput::SetCallback failed.");
+        } else {
+            self.inputCallbackRegistered = YES;
         }
     } else {
         result = input->SetCallback(NULL);
         if (result) {
             NSLog(@"ERROR: IDeckLinkInput::SetCallback failed.");
+        } else {
+            self.inputCallbackRegistered = NO;
         }
     }
     return (result == S_OK);
@@ -675,11 +728,15 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
         result = output->SetScheduledFrameCompletionCallback(callback);
         if (result) {
             NSLog(@"ERROR: IDeckLinkOutput::SetScheduledFrameCompletionCallback failed.");
+        } else {
+            self.outputCallbackRegistered = YES;
         }
     } else {
         result = output->SetScheduledFrameCompletionCallback(NULL);
         if (result) {
             NSLog(@"ERROR: IDeckLinkOutput::SetScheduledFrameCompletionCallback failed.");
+        } else {
+            self.outputCallbackRegistered = NO;
         }
     }
     return (result == S_OK);
@@ -746,11 +803,15 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
         result = manager->SetCallback(callback);
         if (result) {
             NSLog(@"ERROR: IDeckLinkProfileManager::SetCallback failed.");
+        } else {
+            self.profileCallbackRegistered = YES;
         }
     } else {
         result = manager->SetCallback(NULL);
         if (result) {
             NSLog(@"ERROR: IDeckLinkProfileManager::SetCallback failed.");
+        } else {
+            self.profileCallbackRegistered = NO;
         }
     }
     return (result == S_OK);

--- a/Sources/DLABridging/src/DLABDevice.mm
+++ b/Sources/DLABridging/src/DLABDevice.mm
@@ -537,7 +537,7 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
          code:(NSInteger)result
            to:(NSError**)error;
 {
-    return DLABAssignError(error, description, failureReason, (NSInteger)result);
+    return DLABPostError(error, description, failureReason, result);
 }
 
 /* =================================================================================== */

--- a/Sources/DLABridging/src/DLABDevice.mm
+++ b/Sources/DLABridging/src/DLABDevice.mm
@@ -321,18 +321,24 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
         _profileCallback = NULL;
     }
     if (_prefsChangeCallback) {
+        BOOL canReleasePrefsCallback = YES;
         if (_prefsChangeNotificationSubscribed) {
-            [self subscribePrefsChangeNotification:NO];
+            canReleasePrefsCallback = [self subscribePrefsChangeNotification:NO];
         }
-        _prefsChangeCallback->Release();
-        _prefsChangeCallback = NULL;
+        if (canReleasePrefsCallback) {
+            _prefsChangeCallback->Release();
+            _prefsChangeCallback = NULL;
+        }
     }
     if (_statusChangeCallback) {
+        BOOL canReleaseStatusCallback = YES;
         if (_statusChangeNotificationSubscribed) {
-            [self subscribeStatusChangeNotification:NO];
+            canReleaseStatusCallback = [self subscribeStatusChangeNotification:NO];
         }
-        _statusChangeCallback->Release();
-        _statusChangeCallback = NULL;
+        if (canReleaseStatusCallback) {
+            _statusChangeCallback->Release();
+            _statusChangeCallback = NULL;
+        }
     }
     if (_outputCallback) {
         [self subscribeOutput:NO];

--- a/Sources/DLABridging/src/DLABDevice.mm
+++ b/Sources/DLABridging/src/DLABDevice.mm
@@ -70,6 +70,26 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
         outputVideoFrameSet = [NSMutableSet set];
         outputVideoFrameIdleSet = [NSMutableSet set];
         
+        // Eagerly initialize dispatch queues and callback objects to avoid
+        // lazy-initialization races on concurrent first access.
+        _captureQueue = dispatch_queue_create(kCaptureQueue, DISPATCH_QUEUE_SERIAL);
+        captureQueueKey = &captureQueueKey;
+        dispatch_queue_set_specific(_captureQueue, captureQueueKey, (__bridge void*)self, NULL);
+        
+        _playbackQueue = dispatch_queue_create(kPlaybackQueue, DISPATCH_QUEUE_SERIAL);
+        playbackQueueKey = &playbackQueueKey;
+        dispatch_queue_set_specific(_playbackQueue, playbackQueueKey, (__bridge void*)self, NULL);
+        
+        _delegateQueue = dispatch_queue_create(kDelegateQueue, DISPATCH_QUEUE_SERIAL);
+        delegateQueueKey = &delegateQueueKey;
+        dispatch_queue_set_specific(_delegateQueue, delegateQueueKey, (__bridge void*)self, NULL);
+        
+        _inputCallback = new DLABInputCallback((id)self);
+        _outputCallback = new DLABOutputCallback((id)self);
+        _statusChangeCallback = new DLABNotificationCallback((id)self);
+        _prefsChangeCallback = new DLABNotificationCallback((id)self);
+        _profileCallback = new DLABProfileCallback((id)self);
+        
         //
         [self validate];
     }
@@ -880,74 +900,41 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
 
 - (DLABInputCallback *)inputCallback
 {
-    if (!_inputCallback) {
-        _inputCallback = new DLABInputCallback((id)self);
-    }
     return _inputCallback;
 }
 
 - (DLABOutputCallback *)outputCallback
 {
-    if (!_outputCallback) {
-        _outputCallback = new DLABOutputCallback((id)self);
-    }
     return _outputCallback;
 }
 
 - (DLABNotificationCallback*)statusChangeCallback
 {
-    if (!_statusChangeCallback) {
-        _statusChangeCallback = new DLABNotificationCallback((id)self);
-    }
     return _statusChangeCallback;
 }
 
 - (DLABNotificationCallback*)prefsChangeCallback
 {
-    if (!_prefsChangeCallback) {
-        _prefsChangeCallback = new DLABNotificationCallback((id)self);
-    }
     return _prefsChangeCallback;
 }
 
 - (DLABProfileCallback*)profileCallback
 {
-    if (!_profileCallback) {
-        _profileCallback = new DLABProfileCallback((id)self);
-    }
     return _profileCallback;
 }
 
 - (dispatch_queue_t) captureQueue
 {
-    if (!_captureQueue) {
-        _captureQueue = dispatch_queue_create(kCaptureQueue, DISPATCH_QUEUE_SERIAL);
-        captureQueueKey = &captureQueueKey;
-        void *unused = (__bridge void*)self;
-        dispatch_queue_set_specific(_captureQueue, captureQueueKey, unused, NULL);
-    }
     return _captureQueue;
 }
 
 - (dispatch_queue_t) playbackQueue
 {
-    if (!_playbackQueue) {
-        _playbackQueue = dispatch_queue_create(kPlaybackQueue, DISPATCH_QUEUE_SERIAL);
-        playbackQueueKey = &playbackQueueKey;
-        void *unused = (__bridge void*)self;
-        dispatch_queue_set_specific(_playbackQueue, playbackQueueKey, unused, NULL);
-    }
     return _playbackQueue;
 }
 
 - (dispatch_queue_t) delegateQueue
 {
-    if (!_delegateQueue) {
-        _delegateQueue = dispatch_queue_create(kDelegateQueue, DISPATCH_QUEUE_SERIAL);
-        delegateQueueKey = &delegateQueueKey;
-        void *unused = (__bridge void*)self;
-        dispatch_queue_set_specific(_delegateQueue, delegateQueueKey, unused, NULL);
-    }
     return _delegateQueue;
 }
 

--- a/Sources/DLABridging/src/DLABDevice.mm
+++ b/Sources/DLABridging/src/DLABDevice.mm
@@ -98,89 +98,96 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
 
 - (void) validate
 {
-    HRESULT error = E_FAIL;
-    
-    // Validate support feature (capture/playback)
     BOOL supportsCapture = FALSE;
     BOOL supportsPlayback = FALSE;
-    {
-        int64_t support = 0;
-        error = _deckLinkProfileAttributes->GetInt(BMDDeckLinkVideoIOSupport, &support);
-        if (!error) {
-            supportsCapture = (support & bmdDeviceSupportsCapture);
-            supportsPlayback = (support & bmdDeviceSupportsPlayback);
+    
+    [self validateVideoIOSupport:&supportsCapture playback:&supportsPlayback];
+    [self validateOptionalInterfacesForCaptureSupport:&supportsCapture playbackSupport:&supportsPlayback];
+    [self updateSupportFlagsFromCaptureSupport:supportsCapture playbackSupport:supportsPlayback];
+    [self loadStaticDeviceAttributes];
+}
+
+- (void) validateVideoIOSupport:(BOOL *)supportsCapture
+                       playback:(BOOL *)supportsPlayback
+{
+    int64_t support = 0;
+    HRESULT error = _deckLinkProfileAttributes->GetInt(BMDDeckLinkVideoIOSupport, &support);
+    *supportsCapture = FALSE;
+    *supportsPlayback = FALSE;
+    if (!error) {
+        *supportsCapture = (support & bmdDeviceSupportsCapture);
+        *supportsPlayback = (support & bmdDeviceSupportsPlayback);
+    }
+}
+
+- (void) validateOptionalInterfacesForCaptureSupport:(BOOL *)supportsCapture
+                                     playbackSupport:(BOOL *)supportsPlayback
+{
+    HRESULT error = E_FAIL;
+    
+    if (!_deckLinkInput && *supportsCapture) {
+        error = DLABQueryInterfaceAny(_deckLink, &_deckLinkInput,
+                                      IID_IDeckLinkInput,
+                                      IID_IDeckLinkInput_v15_3_1,
+                                      IID_IDeckLinkInput_v14_2_1,
+                                      IID_IDeckLinkInput_v11_5_1,
+                                      IID_IDeckLinkInput_v11_4);
+        if (error) {
+            if (_deckLinkInput) _deckLinkInput->Release();
+            _deckLinkInput = NULL;
+            *supportsCapture = FALSE;
         }
     }
     
-    // Optional c++ objects
-    {
-        // Validate support feature (Capture)
-        if (!_deckLinkInput && supportsCapture) {
-            error = DLABQueryInterfaceAny(_deckLink, &_deckLinkInput,
-                                          IID_IDeckLinkInput,
-                                          IID_IDeckLinkInput_v15_3_1,
-                                          IID_IDeckLinkInput_v14_2_1,
-                                          IID_IDeckLinkInput_v11_5_1,
-                                          IID_IDeckLinkInput_v11_4);
-            if (error) {
-                if (_deckLinkInput) _deckLinkInput->Release();
-                _deckLinkInput = NULL;
-                supportsCapture = FALSE;
-            }
-        }
-        
-        // Validate support feature (Playback)
-        if (!_deckLinkOutput && supportsPlayback) {
-            error = DLABQueryInterfaceAny(_deckLink, &_deckLinkOutput,
-                                          IID_IDeckLinkOutput,
-                                          IID_IDeckLinkOutput_v15_3_1,
-                                          IID_IDeckLinkOutput_v14_2_1,
-                                          IID_IDeckLinkOutput_v11_4);
-            if (error) {
-                if (_deckLinkOutput) _deckLinkOutput->Release();
-                _deckLinkOutput = NULL;
-                supportsPlayback = FALSE;
-            }
-        }
-        
-        // Validate HDMIInputEDID support (optional)
-        if (!_deckLinkHDMIInputEDID && supportsCapture) {
-            error = _deckLink->QueryInterface(IID_IDeckLinkHDMIInputEDID, (void **)&_deckLinkHDMIInputEDID);
-            if (error) {
-                if (_deckLinkHDMIInputEDID) _deckLinkHDMIInputEDID->Release();
-                _deckLinkHDMIInputEDID = NULL;
-            }
-        }
-        
-        // Validate Keyer support (optional)
-        if (!_deckLinkKeyer && supportsPlayback) {
-            error = _deckLink->QueryInterface(IID_IDeckLinkKeyer, (void **)&_deckLinkKeyer);
-            if (error) {
-                if (_deckLinkKeyer) _deckLinkKeyer->Release();
-                _deckLinkKeyer = NULL;
-            }
-        }
-        
-        // Validate Profile support (optional)
-        if (!_deckLinkProfileManager) {
-            error = _deckLink->QueryInterface(IID_IDeckLinkProfileManager, (void **)&_deckLinkProfileManager);
-            if (error) {
-                if (_deckLinkProfileManager) _deckLinkProfileManager->Release();
-                _deckLinkProfileManager = NULL;
-            }
-        }
-        
-        // Validate Statistics support (optional)
-        if (!_deckLinkStatistics) {
-            error = _deckLink->QueryInterface(IID_IDeckLinkStatistics, (void **)&_deckLinkStatistics);
-            if (error) {
-                if (_deckLinkStatistics) _deckLinkStatistics->Release();
-                _deckLinkStatistics = NULL;
-            }
+    if (!_deckLinkOutput && *supportsPlayback) {
+        error = DLABQueryInterfaceAny(_deckLink, &_deckLinkOutput,
+                                      IID_IDeckLinkOutput,
+                                      IID_IDeckLinkOutput_v15_3_1,
+                                      IID_IDeckLinkOutput_v14_2_1,
+                                      IID_IDeckLinkOutput_v11_4);
+        if (error) {
+            if (_deckLinkOutput) _deckLinkOutput->Release();
+            _deckLinkOutput = NULL;
+            *supportsPlayback = FALSE;
         }
     }
     
-    // Validate support feature
+    if (!_deckLinkHDMIInputEDID && *supportsCapture) {
+        error = _deckLink->QueryInterface(IID_IDeckLinkHDMIInputEDID, (void **)&_deckLinkHDMIInputEDID);
+        if (error) {
+            if (_deckLinkHDMIInputEDID) _deckLinkHDMIInputEDID->Release();
+            _deckLinkHDMIInputEDID = NULL;
+        }
+    }
+    
+    if (!_deckLinkKeyer && *supportsPlayback) {
+        error = _deckLink->QueryInterface(IID_IDeckLinkKeyer, (void **)&_deckLinkKeyer);
+        if (error) {
+            if (_deckLinkKeyer) _deckLinkKeyer->Release();
+            _deckLinkKeyer = NULL;
+        }
+    }
+    
+    if (!_deckLinkProfileManager) {
+        error = _deckLink->QueryInterface(IID_IDeckLinkProfileManager, (void **)&_deckLinkProfileManager);
+        if (error) {
+            if (_deckLinkProfileManager) _deckLinkProfileManager->Release();
+            _deckLinkProfileManager = NULL;
+        }
+    }
+    
+    if (!_deckLinkStatistics) {
+        error = _deckLink->QueryInterface(IID_IDeckLinkStatistics, (void **)&_deckLinkStatistics);
+        if (error) {
+            if (_deckLinkStatistics) _deckLinkStatistics->Release();
+            _deckLinkStatistics = NULL;
+        }
+    }
+}
+
+- (void) updateSupportFlagsFromCaptureSupport:(BOOL)supportsCapture
+                              playbackSupport:(BOOL)supportsPlayback
+{
     _supportFlag = DLABVideoIOSupportNone;
     _supportCapture = FALSE;
     _supportPlayback = FALSE;
@@ -195,6 +202,7 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
         _supportPlayback = TRUE;
     }
     if (_deckLinkKeyer) {
+        HRESULT error = E_FAIL;
         bool keyingInternal = false;
         error = _deckLinkProfileAttributes->GetFlag(BMDDeckLinkSupportsInternalKeying, &keyingInternal);
         if (!error && keyingInternal)
@@ -207,8 +215,12 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
         
         _supportKeying = (keyingInternal || keyingExternal);
     }
+}
+
+- (void) loadStaticDeviceAttributes
+{
+    HRESULT error = E_FAIL;
     
-    // Validate attributes
     _modelName = @"Unknown modelName";
     CFStringRef newModelName = nil;
     error = _deckLink->GetModelName(&newModelName);

--- a/Sources/DLABridging/src/DLABDevice.mm
+++ b/Sources/DLABridging/src/DLABDevice.mm
@@ -67,8 +67,7 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
         _deckLink->AddRef();
         
         //
-        outputVideoFrameSet = [NSMutableSet set];
-        outputVideoFrameIdleSet = [NSMutableSet set];
+        _outputVideoFramePool = [[DLABVideoFramePool alloc] init];
         
         // Eagerly initialize dispatch queues and callback objects to avoid
         // lazy-initialization races on concurrent first access.
@@ -297,7 +296,7 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
     }
     
     // Release OutputVideoFramePool
-    [self freeOutputVideoFramePool];
+    [_outputVideoFramePool freeFrames];
     
     // Release CFObjects
     if (_inputPixelBufferPool) {
@@ -501,8 +500,7 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
 @synthesize captureQueueKey = captureQueueKey;
 @synthesize playbackQueueKey = playbackQueueKey;
 @synthesize delegateQueueKey = delegateQueueKey;
-@synthesize outputVideoFrameSet = outputVideoFrameSet;
-@synthesize outputVideoFrameIdleSet = outputVideoFrameIdleSet;
+@synthesize outputVideoFramePool = _outputVideoFramePool;
 
 @synthesize inputPixelBufferPool = _inputPixelBufferPool;
 @synthesize outputPreviewCallback = _outputPreviewCallback;

--- a/Sources/DLABridging/src/DLABDevice.mm
+++ b/Sources/DLABridging/src/DLABDevice.mm
@@ -817,8 +817,8 @@ const char* kDelegateQueue = "DLABDevice.delegateQueue";
 /* =================================================================================== */
 
 - (void) updateSubscriptionFrom:(id)oldValue
-                           to:(id)newValue
-                        block:(BOOL(^)(BOOL))subscribeBlock
+                             to:(id)newValue
+                          block:(BOOL(^)(BOOL))subscribeBlock
 {
     if (oldValue) {
         subscribeBlock(NO);

--- a/Sources/DLABridging/src/DLABProfileAttributes.mm
+++ b/Sources/DLABridging/src/DLABProfileAttributes.mm
@@ -218,7 +218,7 @@
          code:(NSInteger)result
            to:(NSError**)error;
 {
-    return DLABAssignError(error, description, failureReason, (NSInteger)result);
+    return DLABPostError(error, description, failureReason, result);
 }
 
 /* =================================================================================== */

--- a/Sources/DLABridging/src/DLABTimecodeSetting.mm
+++ b/Sources/DLABridging/src/DLABTimecodeSetting.mm
@@ -172,7 +172,7 @@
          code:(NSInteger)result
            to:(NSError**)error;
 {
-    return DLABAssignError(error, description, failureReason, (NSInteger)result);
+    return DLABPostError(error, description, failureReason, result);
 }
 
 /* =================================================================================== */

--- a/Sources/DLABridging/src/DLABVideoConverter.mm
+++ b/Sources/DLABridging/src/DLABVideoConverter.mm
@@ -792,7 +792,7 @@ void endianRGB12U_B2L(vImage_Buffer *buffer) {
     size_t rowBytes = buffer->rowBytes;
     size_t bufSize = rowBytes * height;
     uint8_t* ptr = (uint8_t*)buffer->data;
-    assert(ptr && bufSize);
+    if (!ptr || !bufSize) return;
     if (rowBytes % 3 == 0) {
         for (size_t offset = 0; offset < bufSize; offset += 3) {
             size_t offset0 = (offset + 0), offset1 = (offset + 1), offset2 = (offset + 2);
@@ -825,7 +825,7 @@ void endianRGB12U_L2B(vImage_Buffer *buffer) {
     size_t rowBytes = buffer->rowBytes;
     size_t bufSize = rowBytes * height;
     uint8_t* ptr = (uint8_t*)buffer->data;
-    assert(ptr && bufSize);
+    if (!ptr || !bufSize) return;
     if (rowBytes % 3 == 0) {
         for (size_t offset = 0; offset < bufSize; offset += 3) {
             size_t offset0 = (offset + 0), offset1 = (offset + 1), offset2 = (offset + 2);
@@ -1403,9 +1403,11 @@ void endianRGB12U_L2B(vImage_Buffer *buffer) {
         if (interimErr == kvImageNoError) {
             vImageCVImageFormatRef outFormat = vImageCVImageFormat_CreateWithCVPixelBuffer(pixelBuffer);
             if (outFormat) {
-                assert(kvImageNoError == fillCVColorSpace(outFormat, cvColorSpace));
-                assert(kvImageNoError == fillCVChromaSiting(outFormat, kCVImageBufferChromaLocation_Center));
-                assert(kvImageNoError == fillCVConversionMatrix(outFormat, matrixToYpCbCrFor(dlWidth, dlHeight)));
+                vImage_Error fillErr = fillCVColorSpace(outFormat, cvColorSpace);
+                if (fillErr == kvImageNoError) fillErr = fillCVChromaSiting(outFormat, kCVImageBufferChromaLocation_Center);
+                if (fillErr == kvImageNoError) fillErr = fillCVConversionMatrix(outFormat, matrixToYpCbCrFor(dlWidth, dlHeight));
+                if (fillErr != kvImageNoError) errCGtoCV = fillErr;
+                else {
                 vImage_Flags flags = kvImageNoFlags; // kvImagePrintDiagnosticsToConsole
                 CGFloat bgColor[3] = {0,0,0};
                 convCGtoCV = vImageConverter_CreateForCGToCVImageFormat(&interimFormat,
@@ -1415,6 +1417,7 @@ void endianRGB12U_L2B(vImage_Buffer *buffer) {
                                                                         &errCGtoCV);
                 if (errCGtoCV || !convCGtoCV) {
                     NSLog(@"ERROR: vImageConverter_CreateForCGToCVImageFormat() failed.(%ld)", errCGtoCV);
+                }
                 }
                 vImageCVImageFormat_Release(outFormat);
                 
@@ -1490,7 +1493,10 @@ void endianRGB12U_L2B(vImage_Buffer *buffer) {
                 IDeckLinkVideoFrame_v14_2_1* videoFrame_v14_2_1 = (IDeckLinkVideoFrame_v14_2_1*)videoFrame;
                 videoFrame_v14_2_1->GetBytes(&ptr);
             }
-            assert (ptr != NULL);
+            if (!ptr) {
+                if (!pre1403) VideoBufferUnlockBaseAddress(videoBuffer, accessFlags);
+                return FALSE;
+            }
             
             vImage_Buffer sourceBuffer = {
                 .data = ptr,
@@ -1722,9 +1728,11 @@ void endianRGB12U_L2B(vImage_Buffer *buffer) {
         if (interimErr == kvImageNoError) {
             vImageCVImageFormatRef inFormat = vImageCVImageFormat_CreateWithCVPixelBuffer(pixelBuffer);
             if (inFormat) {
-                assert(kvImageNoError == fillCVColorSpace(inFormat, cvColorSpace));
-                assert(kvImageNoError == fillCVChromaSiting(inFormat, kCVImageBufferChromaLocation_Center));
-                assert(kvImageNoError == fillCVConversionMatrix(inFormat, matrixToYpCbCrFor(dlWidth, dlHeight)));
+                vImage_Error fillErr = fillCVColorSpace(inFormat, cvColorSpace);
+                if (fillErr == kvImageNoError) fillErr = fillCVChromaSiting(inFormat, kCVImageBufferChromaLocation_Center);
+                if (fillErr == kvImageNoError) fillErr = fillCVConversionMatrix(inFormat, matrixToYpCbCrFor(dlWidth, dlHeight));
+                if (fillErr != kvImageNoError) errCVtoCG = fillErr;
+                else {
                 vImage_Flags flags = kvImageNoFlags; // kvImagePrintDiagnosticsToConsole
                 CGFloat bgColor[3] = {0,0,0};
                 convCVtoCG = vImageConverter_CreateForCVToCGImageFormat(inFormat,
@@ -1734,6 +1742,7 @@ void endianRGB12U_L2B(vImage_Buffer *buffer) {
                                                                         &errCVtoCG);
                 if (errCVtoCG || !convCVtoCG) {
                     NSLog(@"ERROR: vImageConverter_CreateForCVToCGImageFormat() failed.(%ld)", errCVtoCG);
+                }
                 }
                 vImageCVImageFormat_Release(inFormat);
                 
@@ -1841,7 +1850,10 @@ void endianRGB12U_L2B(vImage_Buffer *buffer) {
                 IDeckLinkMutableVideoFrame_v14_2_1* videoFrame_v14_2_1 = (IDeckLinkMutableVideoFrame_v14_2_1*)videoFrame;
                 videoFrame_v14_2_1->GetBytes(&ptr);
             }
-            assert (ptr != NULL);
+            if (!ptr) {
+                if (!pre1403) VideoBufferUnlockBaseAddress(videoBuffer, accessFlags);
+                return FALSE;
+            }
             
             vImage_Buffer targetBuffer = {
                 .data = ptr,

--- a/Sources/DLABridging/src/DLABVideoConverter.mm
+++ b/Sources/DLABridging/src/DLABVideoConverter.mm
@@ -1408,16 +1408,16 @@ void endianRGB12U_L2B(vImage_Buffer *buffer) {
                 if (fillErr == kvImageNoError) fillErr = fillCVConversionMatrix(outFormat, matrixToYpCbCrFor(dlWidth, dlHeight));
                 if (fillErr != kvImageNoError) errCGtoCV = fillErr;
                 else {
-                vImage_Flags flags = kvImageNoFlags; // kvImagePrintDiagnosticsToConsole
-                CGFloat bgColor[3] = {0,0,0};
-                convCGtoCV = vImageConverter_CreateForCGToCVImageFormat(&interimFormat,
-                                                                        outFormat,
-                                                                        bgColor,
-                                                                        flags,
-                                                                        &errCGtoCV);
-                if (errCGtoCV || !convCGtoCV) {
-                    NSLog(@"ERROR: vImageConverter_CreateForCGToCVImageFormat() failed.(%ld)", errCGtoCV);
-                }
+                    vImage_Flags flags = kvImageNoFlags; // kvImagePrintDiagnosticsToConsole
+                    CGFloat bgColor[3] = {0,0,0};
+                    convCGtoCV = vImageConverter_CreateForCGToCVImageFormat(&interimFormat,
+                                                                            outFormat,
+                                                                            bgColor,
+                                                                            flags,
+                                                                            &errCGtoCV);
+                    if (errCGtoCV || !convCGtoCV) {
+                        NSLog(@"ERROR: vImageConverter_CreateForCGToCVImageFormat() failed.(%ld)", errCGtoCV);
+                    }
                 }
                 vImageCVImageFormat_Release(outFormat);
                 
@@ -1733,16 +1733,16 @@ void endianRGB12U_L2B(vImage_Buffer *buffer) {
                 if (fillErr == kvImageNoError) fillErr = fillCVConversionMatrix(inFormat, matrixToYpCbCrFor(dlWidth, dlHeight));
                 if (fillErr != kvImageNoError) errCVtoCG = fillErr;
                 else {
-                vImage_Flags flags = kvImageNoFlags; // kvImagePrintDiagnosticsToConsole
-                CGFloat bgColor[3] = {0,0,0};
-                convCVtoCG = vImageConverter_CreateForCVToCGImageFormat(inFormat,
-                                                                        &interimFormat,
-                                                                        bgColor,
-                                                                        flags,
-                                                                        &errCVtoCG);
-                if (errCVtoCG || !convCVtoCG) {
-                    NSLog(@"ERROR: vImageConverter_CreateForCVToCGImageFormat() failed.(%ld)", errCVtoCG);
-                }
+                    vImage_Flags flags = kvImageNoFlags; // kvImagePrintDiagnosticsToConsole
+                    CGFloat bgColor[3] = {0,0,0};
+                    convCVtoCG = vImageConverter_CreateForCVToCGImageFormat(inFormat,
+                                                                            &interimFormat,
+                                                                            bgColor,
+                                                                            flags,
+                                                                            &errCVtoCG);
+                    if (errCVtoCG || !convCVtoCG) {
+                        NSLog(@"ERROR: vImageConverter_CreateForCVToCGImageFormat() failed.(%ld)", errCVtoCG);
+                    }
                 }
                 vImageCVImageFormat_Release(inFormat);
                 

--- a/Sources/DLABridging/src/DLABVideoFramePool.h
+++ b/Sources/DLABridging/src/DLABVideoFramePool.h
@@ -1,0 +1,41 @@
+//
+//  DLABVideoFramePool.h
+//  DLABCore
+//
+//  Created by Takashi Mochizuki on 2024/08/26.
+//  Copyright © 2017-2026 MyCometG3. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#ifdef __cplusplus
+#import <DeckLinkAPI.h>
+
+@class DLABVideoSetting;
+
+/// Manages a bounded pool of IDeckLinkMutableVideoFrame objects for
+/// scheduled playback.  The pool expands on demand (initial unit 4,
+/// subsequent units 2) up to a hard cap of 8 frames.  All internal
+/// state is protected by @synchronized(self).
+@interface DLABVideoFramePool : NSObject
+
+/// Prepare the pool for the given output device and video setting.
+/// Expands the pool if no idle frames are available.  Returns YES
+/// when at least one frame is ready.
+- (BOOL)prepareWithOutput:(IDeckLinkOutput * _Nonnull)output
+                  setting:(DLABVideoSetting * _Nonnull)setting;
+
+/// Reserve a frame from the idle set.  Returns nil when no frame
+/// is available even after expansion.
+- (nullable IDeckLinkMutableVideoFrame *)reserveFrame;
+
+/// Return a previously reserved frame to the idle set.
+/// Returns YES if the frame was recognized and returned.
+- (BOOL)releaseFrame:(IDeckLinkMutableVideoFrame * _Nonnull)frame;
+
+/// Release all frames in the pool and clear both sets.
+- (void)freeFrames;
+
+@end
+
+#endif /* __cplusplus */

--- a/Sources/DLABridging/src/DLABVideoFramePool.h
+++ b/Sources/DLABridging/src/DLABVideoFramePool.h
@@ -25,8 +25,8 @@
 - (BOOL)prepareWithOutput:(IDeckLinkOutput * _Nonnull)output
                   setting:(DLABVideoSetting * _Nonnull)setting;
 
-/// Reserve a frame from the idle set.  Returns nil when no frame
-/// is available even after expansion.
+/// Reserve a frame from the idle set. Call `prepareWithOutput:setting:`
+/// first; returns nil when no prepared idle frame is available.
 - (nullable IDeckLinkMutableVideoFrame *)reserveFrame;
 
 /// Return a previously reserved frame to the idle set.

--- a/Sources/DLABridging/src/DLABVideoFramePool.mm
+++ b/Sources/DLABridging/src/DLABVideoFramePool.mm
@@ -1,0 +1,117 @@
+//
+//  DLABVideoFramePool.mm
+//  DLABCore
+//
+//  Created by Takashi Mochizuki on 2024/08/26.
+//  Copyright © 2017-2026 MyCometG3. All rights reserved.
+//
+
+#import <DLABVideoFramePool.h>
+#import <DLABVideoSetting+Internal.h>
+
+static const int kMaxOutputVideoFrameCount = 8;
+
+@interface DLABVideoFramePool ()
+{
+    NSMutableSet *_frameSet;
+    NSMutableSet *_idleSet;
+}
+@end
+
+@implementation DLABVideoFramePool
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _frameSet = [NSMutableSet set];
+        _idleSet = [NSMutableSet set];
+    }
+    return self;
+}
+
+- (void)dealloc
+{
+    [self freeFrames];
+}
+
+- (BOOL)prepareWithOutput:(IDeckLinkOutput *)output
+                  setting:(DLABVideoSetting *)setting
+{
+    BOOL ret = NO;
+    HRESULT result = E_FAIL;
+    if (output && setting) {
+        @synchronized (self) {
+            BOOL initialSetup = (_frameSet.count == 0);
+            int expandingUnit = initialSetup ? 4 : 2;
+
+            BOOL needsExpansion = (_idleSet.count == 0);
+            if (needsExpansion) {
+                int32_t width = (int32_t)setting.width;
+                int32_t height = (int32_t)setting.height;
+                int32_t rowBytes = (int32_t)setting.rowBytes;
+                BMDPixelFormat pixelFormat = setting.pixelFormat;
+                BMDFrameFlags flags = setting.outputFlag;
+
+                for (int i = 0; i < expandingUnit; i++) {
+                    BOOL poolIsFull = (_frameSet.count >= kMaxOutputVideoFrameCount);
+                    if (poolIsFull) break;
+
+                    IDeckLinkMutableVideoFrame *outFrame = NULL;
+                    result = output->CreateVideoFrame(width, height, rowBytes,
+                                                      pixelFormat, flags, &outFrame);
+                    if (result) break;
+
+                    NSValue* ptrValue = [NSValue valueWithPointer:(void*)outFrame];
+                    [_frameSet addObject:ptrValue];
+                    [_idleSet addObject:ptrValue];
+                }
+            }
+            ret = (_idleSet.count > 0);
+        }
+    }
+    return ret;
+}
+
+- (IDeckLinkMutableVideoFrame *)reserveFrame
+{
+    IDeckLinkMutableVideoFrame *outFrame = NULL;
+    @synchronized (self) {
+        NSValue* ptrValue = [_idleSet anyObject];
+        if (ptrValue) {
+            [_idleSet removeObject:ptrValue];
+            outFrame = (IDeckLinkMutableVideoFrame *)ptrValue.pointerValue;
+        }
+    }
+    return outFrame;
+}
+
+- (BOOL)releaseFrame:(IDeckLinkMutableVideoFrame *)frame
+{
+    BOOL result = NO;
+    @synchronized (self) {
+        NSValue* ptrValue = [NSValue valueWithPointer:(void*)frame];
+        NSValue* orgValue = [_frameSet member:ptrValue];
+        if (orgValue) {
+            [_idleSet addObject:orgValue];
+            result = YES;
+        }
+    }
+    return result;
+}
+
+- (void)freeFrames
+{
+    @synchronized (self) {
+        for (NSValue *ptrValue in _frameSet) {
+            IDeckLinkMutableVideoFrame *outFrame = (IDeckLinkMutableVideoFrame *)ptrValue.pointerValue;
+            if (outFrame) {
+                outFrame->Release();
+            }
+        }
+        [_idleSet removeAllObjects];
+        [_frameSet removeAllObjects];
+    }
+}
+
+@end

--- a/Sources/DLABridging/src/DLABVideoFramePool.mm
+++ b/Sources/DLABridging/src/DLABVideoFramePool.mm
@@ -44,7 +44,7 @@ static const int kMaxOutputVideoFrameCount = 8;
         @synchronized (self) {
             BOOL initialSetup = (_frameSet.count == 0);
             int expandingUnit = initialSetup ? 4 : 2;
-
+            
             BOOL needsExpansion = (_idleSet.count == 0);
             if (needsExpansion) {
                 int32_t width = (int32_t)setting.width;
@@ -52,16 +52,16 @@ static const int kMaxOutputVideoFrameCount = 8;
                 int32_t rowBytes = (int32_t)setting.rowBytes;
                 BMDPixelFormat pixelFormat = setting.pixelFormat;
                 BMDFrameFlags flags = setting.outputFlag;
-
+                
                 for (int i = 0; i < expandingUnit; i++) {
                     BOOL poolIsFull = (_frameSet.count >= kMaxOutputVideoFrameCount);
                     if (poolIsFull) break;
-
+                    
                     IDeckLinkMutableVideoFrame *outFrame = NULL;
                     result = output->CreateVideoFrame(width, height, rowBytes,
                                                       pixelFormat, flags, &outFrame);
                     if (result) break;
-
+                    
                     NSValue* ptrValue = [NSValue valueWithPointer:(void*)outFrame];
                     [_frameSet addObject:ptrValue];
                     [_idleSet addObject:ptrValue];

--- a/Sources/DLABridging/src/DLABVideoSetting.mm
+++ b/Sources/DLABridging/src/DLABVideoSetting.mm
@@ -432,7 +432,7 @@ NS_INLINE BOOL checkPixelFormat(BMDPixelFormat dlPixelFormat, OSType cvPixelForm
          code:(NSInteger)result
            to:(NSError**)error;
 {
-    return DLABAssignError(error, description, failureReason, (NSInteger)result);
+    return DLABPostError(error, description, failureReason, result);
 }
 
 /* =================================================================================== */

--- a/Sources/DLABridgingCpp/include/DLABCallbackBase.h
+++ b/Sources/DLABridgingCpp/include/DLABCallbackBase.h
@@ -1,0 +1,40 @@
+//
+//  DLABCallbackBase.h
+//  DLABCore
+//
+//  Created by Takashi Mochizuki on 2024/09/09.
+//  Copyright © 2017-2026 MyCometG3. All rights reserved.
+//
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+#import <atomic>
+
+/// CRTP base for COM callback classes that share the same pattern:
+/// a __weak delegate, an atomic refCount, and standard AddRef/Release.
+/// Does NOT inherit from IUnknown — each concrete class explicitly
+/// overrides AddRef/Release and delegates to the base to avoid diamond
+/// issues with the COM interface hierarchy.
+template <typename Derived, typename DelegateT>
+class DLABCallbackBase {
+protected:
+    __weak DelegateT delegate;
+    std::atomic<ULONG> refCount{1};
+
+public:
+    explicit DLABCallbackBase(DelegateT delegate) : delegate(delegate) {}
+
+    ULONG AddRef() {
+        return ++refCount;
+    }
+
+    ULONG Release() {
+        ULONG newRefValue = --refCount;
+        if (newRefValue == 0) {
+            delete static_cast<Derived *>(this);
+            return 0;
+        }
+        return newRefValue;
+    }
+};

--- a/Sources/DLABridgingCpp/include/DLABCallbackBase.h
+++ b/Sources/DLABridgingCpp/include/DLABCallbackBase.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #import <Foundation/Foundation.h>
+#import <cstdint>
 #import <atomic>
 
 /// CRTP base for COM callback classes that share the same pattern:
@@ -20,17 +21,17 @@ template <typename Derived, typename DelegateT>
 class DLABCallbackBase {
 protected:
     __weak DelegateT delegate;
-    std::atomic<ULONG> refCount{1};
+    std::atomic<uint32_t> refCount{1};
     
 public:
     explicit DLABCallbackBase(DelegateT delegate) : delegate(delegate) {}
     
-    ULONG AddRef() {
+    uint32_t AddRef() {
         return ++refCount;
     }
     
-    ULONG Release() {
-        ULONG newRefValue = --refCount;
+    uint32_t Release() {
+        uint32_t newRefValue = --refCount;
         if (newRefValue == 0) {
             delete static_cast<Derived *>(this);
             return 0;

--- a/Sources/DLABridgingCpp/include/DLABCallbackBase.h
+++ b/Sources/DLABridgingCpp/include/DLABCallbackBase.h
@@ -21,14 +21,14 @@ class DLABCallbackBase {
 protected:
     __weak DelegateT delegate;
     std::atomic<ULONG> refCount{1};
-
+    
 public:
     explicit DLABCallbackBase(DelegateT delegate) : delegate(delegate) {}
-
+    
     ULONG AddRef() {
         return ++refCount;
     }
-
+    
     ULONG Release() {
         ULONG newRefValue = --refCount;
         if (newRefValue == 0) {

--- a/Sources/DLABridgingCpp/include/DLABDeckControlStatusCallback.h
+++ b/Sources/DLABridgingCpp/include/DLABDeckControlStatusCallback.h
@@ -10,7 +10,7 @@
 
 #import <Foundation/Foundation.h>
 #import <DeckLinkAPI.h>
-#import <atomic>
+#import <DLABCallbackBase.h>
 
 /*
  * Internal use only
@@ -31,10 +31,12 @@
 
 /* =================================================================================== */
 
-class DLABDeckControlStatusCallback : public IDeckLinkDeckControlStatusCallback
+class DLABDeckControlStatusCallback : public IDeckLinkDeckControlStatusCallback,
+                                       public DLABCallbackBase<DLABDeckControlStatusCallback, id<DLABDeckControlStatusCallbackPrivateDelegate>>
 {
+    using Base = DLABCallbackBase<DLABDeckControlStatusCallback, id<DLABDeckControlStatusCallbackPrivateDelegate>>;
 public:
-    DLABDeckControlStatusCallback(id<DLABDeckControlStatusCallbackPrivateDelegate> delegate);
+    using Base::Base;
     
     // IDeckLinkDeckControlStatusCallback
     HRESULT TimecodeUpdate(BMDTimecodeBCD currentTimecode) override;
@@ -44,10 +46,6 @@ public:
     
     // IUnknown
     HRESULT QueryInterface(REFIID iid, LPVOID *ppv) override;
-    ULONG AddRef() override;
-    ULONG Release() override;
-    
-private:
-    __weak id<DLABDeckControlStatusCallbackPrivateDelegate> delegate;
-    std::atomic<ULONG> refCount;
+    ULONG AddRef() override { return Base::AddRef(); }
+    ULONG Release() override { return Base::Release(); }
 };

--- a/Sources/DLABridgingCpp/include/DLABDeviceNotificationCallback.h
+++ b/Sources/DLABridgingCpp/include/DLABDeviceNotificationCallback.h
@@ -10,7 +10,7 @@
 
 #import <Foundation/Foundation.h>
 #import <DeckLinkAPI.h>
-#import <atomic>
+#import <DLABCallbackBase.h>
 
 /*
  * Internal use only
@@ -29,10 +29,12 @@
 
 /* =================================================================================== */
 
-class DLABDeviceNotificationCallback : public IDeckLinkDeviceNotificationCallback
+class DLABDeviceNotificationCallback : public IDeckLinkDeviceNotificationCallback,
+                                         public DLABCallbackBase<DLABDeviceNotificationCallback, id<DLABDeviceNotificationCallbackDelegate>>
 {
+    using Base = DLABCallbackBase<DLABDeviceNotificationCallback, id<DLABDeviceNotificationCallbackDelegate>>;
 public:
-    DLABDeviceNotificationCallback(id<DLABDeviceNotificationCallbackDelegate> delegate);
+    using Base::Base;
     
     // IDeckLinkDeviceNotificationCallback
     HRESULT DeckLinkDeviceArrived(IDeckLink *deckLink) override;
@@ -40,10 +42,6 @@ public:
     
     // IUnknown
     HRESULT QueryInterface(REFIID iid, LPVOID *ppv) override;
-    ULONG AddRef() override;
-    ULONG Release() override;
-    
-private:
-    __weak id<DLABDeviceNotificationCallbackDelegate> delegate;
-    std::atomic<ULONG> refCount;
+    ULONG AddRef() override { return Base::AddRef(); }
+    ULONG Release() override { return Base::Release(); }
 };

--- a/Sources/DLABridgingCpp/include/DLABInputCallback.h
+++ b/Sources/DLABridgingCpp/include/DLABInputCallback.h
@@ -12,7 +12,7 @@
 #import <DeckLinkAPI.h>
 #import <DeckLinkAPIVideoInput_v14_2_1.h>
 #import <DeckLinkAPIVideoInput_v11_5_1.h>
-#import <atomic>
+#import <DLABCallbackBase.h>
 
 /*
  * Internal use only
@@ -31,10 +31,12 @@
 
 /* =================================================================================== */
 
-class DLABInputCallback : public IDeckLinkInputCallback
+class DLABInputCallback : public IDeckLinkInputCallback,
+                           public DLABCallbackBase<DLABInputCallback, id<DLABInputCallbackDelegate>>
 {
+    using Base = DLABCallbackBase<DLABInputCallback, id<DLABInputCallbackDelegate>>;
 public:
-    DLABInputCallback(id<DLABInputCallbackDelegate> delegate);
+    using Base::Base;
     
     // IDeckLinkInputCallback
     HRESULT VideoInputFormatChanged(BMDVideoInputFormatChangedEvents notificationEvents, IDeckLinkDisplayMode *newDisplayMode, BMDDetectedVideoInputFormatFlags detectedSignalFlags) override;
@@ -42,10 +44,6 @@ public:
     
     // IUnknown
     HRESULT QueryInterface(REFIID iid, LPVOID *ppv) override;
-    ULONG AddRef() override;
-    ULONG Release() override;
-    
-private:
-    __weak id<DLABInputCallbackDelegate> delegate;
-    std::atomic<ULONG> refCount;
+    ULONG AddRef() override { return Base::AddRef(); }
+    ULONG Release() override { return Base::Release(); }
 };

--- a/Sources/DLABridgingCpp/include/DLABNotificationCallback.h
+++ b/Sources/DLABridgingCpp/include/DLABNotificationCallback.h
@@ -10,7 +10,7 @@
 
 #import <Foundation/Foundation.h>
 #import <DeckLinkAPI.h>
-#import <atomic>
+#import <DLABCallbackBase.h>
 
 /*
  * Internal use only
@@ -28,20 +28,18 @@
 
 /* =================================================================================== */
 
-class DLABNotificationCallback : public IDeckLinkNotificationCallback
+class DLABNotificationCallback : public IDeckLinkNotificationCallback,
+                                   public DLABCallbackBase<DLABNotificationCallback, id<DLABNotificationCallbackDelegate>>
 {
+    using Base = DLABCallbackBase<DLABNotificationCallback, id<DLABNotificationCallbackDelegate>>;
 public:
-    DLABNotificationCallback(id<DLABNotificationCallbackDelegate> delegate);
+    using Base::Base;
     
     // IDeckLinkNotificationCallback
     HRESULT Notify(BMDNotifications topic, uint64_t param1, uint64_t param2) override;
     
     // IUnknown
     HRESULT QueryInterface(REFIID iid, LPVOID *ppv) override;
-    ULONG AddRef() override;
-    ULONG Release() override;
-    
-private:
-    __weak id<DLABNotificationCallbackDelegate> delegate;
-    std::atomic<ULONG> refCount;
+    ULONG AddRef() override { return Base::AddRef(); }
+    ULONG Release() override { return Base::Release(); }
 };

--- a/Sources/DLABridgingCpp/include/DLABOutputCallback.h
+++ b/Sources/DLABridgingCpp/include/DLABOutputCallback.h
@@ -11,7 +11,7 @@
 #import <Foundation/Foundation.h>
 #import <DeckLinkAPI.h>
 #import <DeckLinkAPI_v14_2_1.h>
-#import <atomic>
+#import <DLABCallbackBase.h>
 
 /*
  * Internal use only
@@ -32,10 +32,13 @@
 
 /* =================================================================================== */
 
-class DLABOutputCallback : public IDeckLinkVideoOutputCallback, public IDeckLinkAudioOutputCallback
+class DLABOutputCallback : public IDeckLinkVideoOutputCallback,
+                            public IDeckLinkAudioOutputCallback,
+                            public DLABCallbackBase<DLABOutputCallback, id<DLABOutputCallbackDelegate>>
 {
+    using Base = DLABCallbackBase<DLABOutputCallback, id<DLABOutputCallbackDelegate>>;
 public:
-    DLABOutputCallback(id<DLABOutputCallbackDelegate> delegate);
+    using Base::Base;
     
     // IDeckLinkVideoOutputCallback
     HRESULT ScheduledFrameCompleted(IDeckLinkVideoFrame *completedFrame, BMDOutputFrameCompletionResult result) override;
@@ -46,10 +49,6 @@ public:
     
     // IUnknown
     HRESULT QueryInterface(REFIID iid, LPVOID *ppv) override;
-    ULONG AddRef() override;
-    ULONG Release() override;
-    
-private:
-    __weak id<DLABOutputCallbackDelegate> delegate;
-    std::atomic<ULONG> refCount;
+    ULONG AddRef() override { return Base::AddRef(); }
+    ULONG Release() override { return Base::Release(); }
 };

--- a/Sources/DLABridgingCpp/include/DLABProfileCallback.h
+++ b/Sources/DLABridgingCpp/include/DLABProfileCallback.h
@@ -10,7 +10,7 @@
 
 #import <Foundation/Foundation.h>
 #import <DeckLinkAPI.h>
-#import <atomic>
+#import <DLABCallbackBase.h>
 
 /*
  * Internal use only
@@ -29,10 +29,12 @@
 
 /* =================================================================================== */
 
-class DLABProfileCallback : public IDeckLinkProfileCallback
+class DLABProfileCallback : public IDeckLinkProfileCallback,
+                              public DLABCallbackBase<DLABProfileCallback, id<DLABProfileCallbackPrivateDelegate>>
 {
+    using Base = DLABCallbackBase<DLABProfileCallback, id<DLABProfileCallbackPrivateDelegate>>;
 public:
-    DLABProfileCallback(id<DLABProfileCallbackPrivateDelegate> delegate);
+    using Base::Base;
     
     // IDeckLinkProfileCallback
     HRESULT ProfileChanging(IDeckLinkProfile* profileToBeActivated, bool streamsWillBeForcedToStop) override;
@@ -40,10 +42,6 @@ public:
     
     // IUnknown
     HRESULT QueryInterface(REFIID iid, LPVOID *ppv) override;
-    ULONG AddRef() override;
-    ULONG Release() override;
-    
-private:
-    __weak id<DLABProfileCallbackPrivateDelegate> delegate;
-    std::atomic<ULONG> refCount;
+    ULONG AddRef() override { return Base::AddRef(); }
+    ULONG Release() override { return Base::Release(); }
 };

--- a/Sources/DLABridgingCpp/include/DLABQueryInterfaceAny.h
+++ b/Sources/DLABridgingCpp/include/DLABQueryInterfaceAny.h
@@ -37,11 +37,11 @@ static inline HRESULT DLABQueryInterfaceAny(SourceT* source,
         return E_POINTER;
     }
     *out = nullptr;
-
+    
     if (!source) {
         return E_NOINTERFACE;
     }
-
+    
     for (REFIID iid : iids) {
         OutputT* candidate = nullptr;
         HRESULT hr = source->QueryInterface(iid, reinterpret_cast<void**>(&candidate));
@@ -49,12 +49,12 @@ static inline HRESULT DLABQueryInterfaceAny(SourceT* source,
             *out = candidate;
             return S_OK;
         }
-
+        
         if (candidate) {
             candidate->Release();
         }
     }
-
+    
     return E_NOINTERFACE;
 }
 

--- a/Sources/DLABridgingCpp/src/DLABAncillaryPacket.mm
+++ b/Sources/DLABridgingCpp/src/DLABAncillaryPacket.mm
@@ -27,7 +27,7 @@ HRESULT DLABAncillaryPacket::Update(uint8_t did, uint8_t sdid, uint32_t line, ui
     if (!data) {
         return E_INVALIDARG;
     }
-
+    
     const uint8_t* ptr = (const uint8_t*)data.bytes;
     const size_t length = (size_t)data.length;
     if (length == 0) {
@@ -35,13 +35,13 @@ HRESULT DLABAncillaryPacket::Update(uint8_t did, uint8_t sdid, uint32_t line, ui
     } else {
         vbuf.assign((const char*)ptr, (const char*)ptr + length);
     }
-
+    
     _did = did;
     _sdid = sdid;
     _line = line;
     _dataStreamIndex = dataStreamIndex;
     _dataSpace = dataSpace;
-
+    
     return S_OK;
 }
 

--- a/Sources/DLABridgingCpp/src/DLABDeckControlStatusCallback.mm
+++ b/Sources/DLABridgingCpp/src/DLABDeckControlStatusCallback.mm
@@ -10,11 +10,6 @@
 
 #import <DLABDeckControlStatusCallback.h>
 
-DLABDeckControlStatusCallback::DLABDeckControlStatusCallback(id<DLABDeckControlStatusCallbackPrivateDelegate> delegate)
-: delegate(delegate), refCount(1)
-{
-}
-
 // IDeckLinkDeckControlStatusCallback
 
 HRESULT DLABDeckControlStatusCallback::TimecodeUpdate(BMDTimecodeBCD currentTimecode)
@@ -66,20 +61,4 @@ HRESULT DLABDeckControlStatusCallback::QueryInterface(REFIID iid, LPVOID *ppv)
     }
     
     return E_NOINTERFACE;
-}
-
-ULONG DLABDeckControlStatusCallback::AddRef()
-{
-    ULONG newRefValue = ++refCount;
-    return newRefValue;
-}
-
-ULONG DLABDeckControlStatusCallback::Release()
-{
-    ULONG newRefValue = --refCount;
-    if (newRefValue == 0) {
-        delete this;
-        return 0;
-    }
-    return newRefValue;
 }

--- a/Sources/DLABridgingCpp/src/DLABDeviceNotificationCallback.mm
+++ b/Sources/DLABridgingCpp/src/DLABDeviceNotificationCallback.mm
@@ -10,11 +10,6 @@
 
 #import <DLABDeviceNotificationCallback.h>
 
-DLABDeviceNotificationCallback::DLABDeviceNotificationCallback(id<DLABDeviceNotificationCallbackDelegate> delegate)
-: delegate(delegate), refCount(1)
-{
-}
-
 HRESULT DLABDeviceNotificationCallback::DeckLinkDeviceArrived(IDeckLink *deckLink)
 {
     if ([delegate respondsToSelector:@selector(didAddDevice:)]) {
@@ -46,20 +41,4 @@ HRESULT DLABDeviceNotificationCallback::QueryInterface(REFIID iid, LPVOID *ppv)
         return S_OK;
     }
     return E_NOINTERFACE;
-}
-
-ULONG DLABDeviceNotificationCallback::AddRef()
-{
-    ULONG newRefValue = ++refCount;
-    return newRefValue;
-}
-
-ULONG DLABDeviceNotificationCallback::Release()
-{
-    ULONG newRefValue = --refCount;
-    if (newRefValue == 0) {
-        delete this;
-        return 0;
-    }
-    return newRefValue;
 }

--- a/Sources/DLABridgingCpp/src/DLABInputCallback.mm
+++ b/Sources/DLABridgingCpp/src/DLABInputCallback.mm
@@ -11,11 +11,6 @@
 #import <DLABInputCallback.h>
 #import <DLABQueryInterfaceAny.h>
 
-DLABInputCallback::DLABInputCallback(id<DLABInputCallbackDelegate> delegate)
-: delegate(delegate), refCount(1)
-{
-}
-
 // DLABInputCallbackDelegate
 
 HRESULT DLABInputCallback::VideoInputFormatChanged(BMDVideoInputFormatChangedEvents notificationEvents, IDeckLinkDisplayMode *newDisplayMode, BMDDetectedVideoInputFormatFlags detectedSignalFlags)
@@ -56,20 +51,4 @@ HRESULT DLABInputCallback::QueryInterface(REFIID iid, LPVOID *ppv)
         return S_OK;
     }
     return E_NOINTERFACE;
-}
-
-ULONG DLABInputCallback::AddRef()
-{
-    ULONG newRefValue = ++refCount;
-    return newRefValue;
-}
-
-ULONG DLABInputCallback::Release()
-{
-    ULONG newRefValue = --refCount;
-    if (newRefValue == 0) {
-        delete this;
-        return 0;
-    }
-    return newRefValue;
 }

--- a/Sources/DLABridgingCpp/src/DLABNotificationCallback.mm
+++ b/Sources/DLABridgingCpp/src/DLABNotificationCallback.mm
@@ -10,11 +10,6 @@
 
 #import <DLABNotificationCallback.h>
 
-DLABNotificationCallback::DLABNotificationCallback(id<DLABNotificationCallbackDelegate> delegate)
-: delegate(delegate), refCount(1)
-{
-}
-
 HRESULT DLABNotificationCallback::Notify(BMDNotifications topic, uint64_t param1, uint64_t param2)
 {
     if (delegate && [delegate respondsToSelector:@selector(notify:param1:param2:)]) {
@@ -39,20 +34,4 @@ HRESULT DLABNotificationCallback::QueryInterface(REFIID iid, LPVOID *ppv)
         return S_OK;
     }
     return E_NOINTERFACE;
-}
-
-ULONG DLABNotificationCallback::AddRef()
-{
-    ULONG newRefValue = ++refCount;
-    return newRefValue;
-}
-
-ULONG DLABNotificationCallback::Release()
-{
-    ULONG newRefValue = --refCount;
-    if (newRefValue == 0) {
-        delete this;
-        return 0;
-    }
-    return newRefValue;
 }

--- a/Sources/DLABridgingCpp/src/DLABOutputCallback.mm
+++ b/Sources/DLABridgingCpp/src/DLABOutputCallback.mm
@@ -11,11 +11,6 @@
 #import <DLABOutputCallback.h>
 #import <DLABQueryInterfaceAny.h>
 
-DLABOutputCallback::DLABOutputCallback(id<DLABOutputCallbackDelegate> delegate)
-: delegate(delegate), refCount(1)
-{
-}
-
 // IDeckLinkVideoOutputCallback
 
 HRESULT DLABOutputCallback::ScheduledFrameCompleted(IDeckLinkVideoFrame *completedFrame, BMDOutputFrameCompletionResult result)
@@ -71,20 +66,4 @@ HRESULT DLABOutputCallback::QueryInterface(REFIID iid, LPVOID *ppv)
         return S_OK;
     }
     return E_NOINTERFACE;
-}
-
-ULONG DLABOutputCallback::AddRef()
-{
-    ULONG newRefValue = ++refCount;
-    return newRefValue;
-}
-
-ULONG DLABOutputCallback::Release()
-{
-    ULONG newRefValue = --refCount;
-    if (newRefValue == 0) {
-        delete this;
-        return 0;
-    }
-    return newRefValue;
 }

--- a/Sources/DLABridgingCpp/src/DLABProfileCallback.mm
+++ b/Sources/DLABridgingCpp/src/DLABProfileCallback.mm
@@ -10,11 +10,6 @@
 
 #import <DLABProfileCallback.h>
 
-DLABProfileCallback::DLABProfileCallback(id<DLABProfileCallbackPrivateDelegate> delegate)
-: delegate(delegate), refCount(1)
-{
-}
-
 HRESULT DLABProfileCallback::ProfileChanging(IDeckLinkProfile* profileToBeActivated, bool streamsWillBeForcedToStop)
 {
     if ([delegate respondsToSelector:@selector(willApplyProfile:stopping:)]) {
@@ -46,20 +41,4 @@ HRESULT DLABProfileCallback::QueryInterface(REFIID iid, LPVOID *ppv)
         return S_OK;
     }
     return E_NOINTERFACE;
-}
-
-ULONG DLABProfileCallback::AddRef()
-{
-    ULONG newRefValue = ++refCount;
-    return newRefValue;
-}
-
-ULONG DLABProfileCallback::Release()
-{
-    ULONG newRefValue = --refCount;
-    if (newRefValue == 0) {
-        delete this;
-        return 0;
-    }
-    return newRefValue;
 }


### PR DESCRIPTION
## Summary
- harden capture and bridging safety by fixing DLABDevice lazy initialization, replacing runtime-critical asserts, tightening CaptureManager state access, and adding bounded backpressure for callback processing
- reduce duplication across the bridging layer by deduplicating error posting, delegate subscription boilerplate, C++ callback refcount logic, and by splitting DLABDevice validation into focused helpers
- improve playback-side structure by extracting the output video frame pool and carry forward the reviewed cleanup set into a single integration branch targeting `work`