### PR TITLE
Integrate second review fixes into work

### DIFF
--- a/Sources/DLABCapture/AACFamilyHelper.swift
+++ b/Sources/DLABCapture/AACFamilyHelper.swift
@@ -1,0 +1,15 @@
+//
+//  AACFamilyHelper.swift
+//  DLABCapture
+//
+//  Created by Takashi Mochizuki on 2026/05/11.
+//  Copyright © 2026 MyCometG3. All rights reserved.
+//
+
+import AudioToolbox
+
+/// Returns true if the AudioFormatID is within the AAC family range
+/// (MPEG-4 AAC through HE-AAC v2).
+internal func isAACFamily(_ formatID: UInt32) -> Bool {
+    return (formatID >= kAudioFormatMPEG4AAC && formatID <= kAudioFormatMPEG4AAC_HE_V2)
+}

--- a/Sources/DLABCapture/AudioChannelLayoutHelper.swift
+++ b/Sources/DLABCapture/AudioChannelLayoutHelper.swift
@@ -702,17 +702,6 @@ extension CaptureWriter {
     }
     
     /* ============================================ */
-    // MARK: - AudioFormatID Utility Functions
-    /* ============================================ */
-    
-    /// Check if the given format ID is part of the AAC family.
-    /// - Parameter formatID: The AudioFormatID to check
-    /// - Returns: true if the format ID is part of the AAC family, false otherwise
-    private func isAACFamily(_ formatID: UInt32) -> Bool {
-        return (formatID >= kAudioFormatMPEG4AAC && formatID <= kAudioFormatMPEG4AAC_HE_V2)
-    }
-    
-    /* ============================================ */
     // MARK: - CMBlockBuffer Utility Functions
     /* ============================================ */
     

--- a/Sources/DLABCapture/CaptureAudioPreview.swift
+++ b/Sources/DLABCapture/CaptureAudioPreview.swift
@@ -227,16 +227,6 @@ class CaptureAudioPreview: NSObject, @unchecked Sendable {
         }
     }
     
-    private func createError(_ status :OSStatus, _ description :String?, _ failureReason :String?) -> NSError {
-        let domain = "com.MyCometG3.DLABCaptureManager.ErrorDomain"
-        let code = NSInteger(status)
-        let desc = description ?? "unknown description"
-        let reason = failureReason ?? "unknown failureReason"
-        let userInfo :[String:Any] = [NSLocalizedDescriptionKey:desc,
-                               NSLocalizedFailureReasonErrorKey:reason]
-        return NSError(domain: domain, code: code, userInfo: userInfo)
-    }
-    
     /// Extract ASBD from Audio CMSampleBuffer
     ///
     /// - Parameter sampleBuffer: Audio CMSampleBuffer

--- a/Sources/DLABCapture/CaptureErrorHelper.swift
+++ b/Sources/DLABCapture/CaptureErrorHelper.swift
@@ -1,0 +1,23 @@
+//
+//  CaptureErrorHelper.swift
+//  DLABCapture
+//
+//  Created by Takashi Mochizuki on 2026/05/11.
+//  Copyright © 2026 MyCometG3. All rights reserved.
+//
+
+import Foundation
+
+private let errorDomain = "com.MyCometG3.DLABCaptureManager.ErrorDomain"
+
+/// Create an NSError in the shared DLABCapture error domain.
+internal func createError(_ status: OSStatus,
+                          _ description: String?,
+                          _ failureReason: String?) -> NSError {
+    let code = NSInteger(status)
+    let desc = description ?? "unknown description"
+    let reason = failureReason ?? "unknown failureReason"
+    let userInfo: [String: Any] = [NSLocalizedDescriptionKey: desc,
+                                   NSLocalizedFailureReasonErrorKey: reason]
+    return NSError(domain: errorDomain, code: code, userInfo: userInfo)
+}

--- a/Sources/DLABCapture/CaptureManager+Util.swift
+++ b/Sources/DLABCapture/CaptureManager+Util.swift
@@ -224,14 +224,14 @@ extension CaptureManager {
     
     /// Native Timescale for DisplayMode
     /// - Parameter targetDisplayMode: DLABDisplayMode
-    /// - Returns: CMTimeScale
+    /// - Returns: The native CMTimeScale for the display mode, or nil when the mode is unsupported.
     public func nativeTimescaleFor(_ targetDisplayMode:DLABDisplayMode) -> CMTimeScale? {
         Self.displayModeTiming[targetDisplayMode]?.timescale
     }
     
     /// Native video frame rate for DisplayMode
     /// - Parameter targetDisplayMode: DLABDisplayMode
-    /// - Returns: FPS in Float
+    /// - Returns: The native frame rate for the display mode, or nil when the mode is unsupported.
     public func nativeFPSFor(_ targetDisplayMode:DLABDisplayMode) -> Float? {
         Self.displayModeTiming[targetDisplayMode]?.fps
     }

--- a/Sources/DLABCapture/CaptureManager+Util.swift
+++ b/Sources/DLABCapture/CaptureManager+Util.swift
@@ -20,7 +20,7 @@ extension CaptureManager {
     
     private static let displayModeTiming: [DLABDisplayMode: DisplayModeTiming] = [
         .modeNTSC:           DisplayModeTiming(timescale: 30000, fps: 30.0/1.001),
-        .modeNTSC2398:       DisplayModeTiming(timescale: 24000, fps: 30.0/1.001),
+        .modeNTSC2398:       DisplayModeTiming(timescale: 24000, fps: 24.0/1.001),
         .modeNTSCp:          DisplayModeTiming(timescale: 60000, fps: 60.0/1.001),
         .modePAL:            DisplayModeTiming(timescale: 25000, fps: 25.0),
         .modePALp:           DisplayModeTiming(timescale: 50000, fps: 50.0),

--- a/Sources/DLABCapture/CaptureManager+Util.swift
+++ b/Sources/DLABCapture/CaptureManager+Util.swift
@@ -11,6 +11,98 @@ import Cocoa
 
 extension CaptureManager {
     
+    // MARK: - Display mode timing table
+    
+    private struct DisplayModeTiming {
+        let timescale: CMTimeScale
+        let fps: Float
+    }
+    
+    private static let displayModeTiming: [DLABDisplayMode: DisplayModeTiming] = [
+        .modeNTSC:           DisplayModeTiming(timescale: 30000, fps: 30.0/1.001),
+        .modeNTSC2398:       DisplayModeTiming(timescale: 24000, fps: 30.0/1.001),
+        .modeNTSCp:          DisplayModeTiming(timescale: 60000, fps: 60.0/1.001),
+        .modePAL:            DisplayModeTiming(timescale: 25000, fps: 25.0),
+        .modePALp:           DisplayModeTiming(timescale: 50000, fps: 50.0),
+        
+        .modeHD720p50:       DisplayModeTiming(timescale: 50000, fps: 50.0),
+        .modeHD720p5994:     DisplayModeTiming(timescale: 60000, fps: 60.0/1.001),
+        .modeHD720p60:       DisplayModeTiming(timescale: 60000, fps: 60.0),
+        
+        .modeHD1080p2398:    DisplayModeTiming(timescale: 24000, fps: 24.0/1.001),
+        .modeHD1080p24:      DisplayModeTiming(timescale: 24000, fps: 24.0),
+        .modeHD1080p25:      DisplayModeTiming(timescale: 25000, fps: 25.0),
+        .modeHD1080p2997:    DisplayModeTiming(timescale: 30000, fps: 30.0/1.001),
+        .modeHD1080p30:      DisplayModeTiming(timescale: 30000, fps: 30.0),
+        .modeHD1080p4795:    DisplayModeTiming(timescale: 48000, fps: 48.0/1.001),
+        .modeHD1080p48:      DisplayModeTiming(timescale: 48000, fps: 48.0),
+        .modeHD1080i50:      DisplayModeTiming(timescale: 25000, fps: 25.0),
+        .modeHD1080i5994:    DisplayModeTiming(timescale: 30000, fps: 30.0/1.001),
+        .modeHD1080i6000:    DisplayModeTiming(timescale: 30000, fps: 30.0),
+        .modeHD1080p50:      DisplayModeTiming(timescale: 50000, fps: 50.0),
+        .modeHD1080p5994:    DisplayModeTiming(timescale: 60000, fps: 60.0/1.001),
+        .modeHD1080p6000:    DisplayModeTiming(timescale: 60000, fps: 60.0),
+        .modeHD1080p9590:    DisplayModeTiming(timescale: 96000, fps: 96.0/1.001),
+        .modeHD1080p96:      DisplayModeTiming(timescale: 96000, fps: 96.0),
+        .modeHD1080p100:     DisplayModeTiming(timescale: 100000, fps: 100.0),
+        .modeHD1080p11988:   DisplayModeTiming(timescale: 120000, fps: 120.0/1.001),
+        .modeHD1080p120:     DisplayModeTiming(timescale: 120000, fps: 120.0),
+        
+        .mode2k2398:         DisplayModeTiming(timescale: 24000, fps: 24.0/1.001),
+        .mode2k24:           DisplayModeTiming(timescale: 24000, fps: 24.0),
+        .mode2k25:           DisplayModeTiming(timescale: 25000, fps: 25.0),
+        
+        .mode2kDCI2398:      DisplayModeTiming(timescale: 24000, fps: 24.0/1.001),
+        .mode2kDCI24:        DisplayModeTiming(timescale: 24000, fps: 24.0),
+        .mode2kDCI25:        DisplayModeTiming(timescale: 25000, fps: 25.0),
+        .mode2kDCI2997:      DisplayModeTiming(timescale: 30000, fps: 30.0/1.001),
+        .mode2kDCI30:        DisplayModeTiming(timescale: 30000, fps: 30.0),
+        .mode2kDCI4795:      DisplayModeTiming(timescale: 48000, fps: 48.0/1.001),
+        .mode2kDCI48:        DisplayModeTiming(timescale: 48000, fps: 48.0),
+        .mode2kDCI50:        DisplayModeTiming(timescale: 50000, fps: 50.0),
+        .mode2kDCI5994:      DisplayModeTiming(timescale: 60000, fps: 60.0/1.001),
+        .mode2kDCI60:        DisplayModeTiming(timescale: 60000, fps: 60.0),
+        .mode2kDCI9590:      DisplayModeTiming(timescale: 96000, fps: 96.0/1.001),
+        .mode2kDCI96:        DisplayModeTiming(timescale: 96000, fps: 96.0),
+        .mode2kDCI100:       DisplayModeTiming(timescale: 100000, fps: 100.0),
+        .mode2kDCI11988:     DisplayModeTiming(timescale: 120000, fps: 120.0/1.001),
+        .mode2kDCI120:       DisplayModeTiming(timescale: 120000, fps: 120.0),
+        
+        .mode4K2160p2398:    DisplayModeTiming(timescale: 24000, fps: 24.0/1.001),
+        .mode4K2160p24:      DisplayModeTiming(timescale: 24000, fps: 24.0),
+        .mode4K2160p25:      DisplayModeTiming(timescale: 25000, fps: 25.0),
+        .mode4K2160p2997:    DisplayModeTiming(timescale: 30000, fps: 30.0/1.001),
+        .mode4K2160p30:      DisplayModeTiming(timescale: 30000, fps: 30.0),
+        .mode4K2160p4795:    DisplayModeTiming(timescale: 48000, fps: 48.0/1.001),
+        .mode4K2160p48:      DisplayModeTiming(timescale: 48000, fps: 48.0),
+        .mode4K2160p50:      DisplayModeTiming(timescale: 50000, fps: 50.0),
+        .mode4K2160p5994:    DisplayModeTiming(timescale: 60000, fps: 60.0/1.001),
+        .mode4K2160p60:      DisplayModeTiming(timescale: 60000, fps: 60.0),
+        .mode4K2160p9590:    DisplayModeTiming(timescale: 96000, fps: 96.0/1.001),
+        .mode4K2160p96:      DisplayModeTiming(timescale: 96000, fps: 96.0),
+        .mode4K2160p100:     DisplayModeTiming(timescale: 100000, fps: 100.0),
+        .mode4K2160p11988:   DisplayModeTiming(timescale: 120000, fps: 120.0/1.001),
+        .mode4K2160p120:     DisplayModeTiming(timescale: 120000, fps: 120.0),
+        
+        .mode4kDCI2398:      DisplayModeTiming(timescale: 24000, fps: 24.0/1.001),
+        .mode4kDCI24:        DisplayModeTiming(timescale: 24000, fps: 24.0),
+        .mode4kDCI25:        DisplayModeTiming(timescale: 25000, fps: 25.0),
+        .mode4kDCI2997:      DisplayModeTiming(timescale: 30000, fps: 30.0/1.001),
+        .mode4kDCI30:        DisplayModeTiming(timescale: 30000, fps: 30.0),
+        .mode4kDCI4795:      DisplayModeTiming(timescale: 48000, fps: 48.0/1.001),
+        .mode4kDCI48:        DisplayModeTiming(timescale: 48000, fps: 48.0),
+        .mode4kDCI50:        DisplayModeTiming(timescale: 50000, fps: 50.0),
+        .mode4kDCI5994:      DisplayModeTiming(timescale: 60000, fps: 60.0/1.001),
+        .mode4kDCI60:        DisplayModeTiming(timescale: 60000, fps: 60.0),
+        .mode4kDCI9590:      DisplayModeTiming(timescale: 96000, fps: 96.0/1.001),
+        .mode4kDCI96:        DisplayModeTiming(timescale: 96000, fps: 96.0),
+        .mode4kDCI100:       DisplayModeTiming(timescale: 100000, fps: 100.0),
+        .mode4kDCI11988:     DisplayModeTiming(timescale: 120000, fps: 120.0/1.001),
+        .mode4kDCI120:       DisplayModeTiming(timescale: 120000, fps: 120.0),
+        
+        // TODO .mode8K...
+    ]
+    
     /* ============================================ */
     // MARK: - public utility
     /* ============================================ */
@@ -134,200 +226,14 @@ extension CaptureManager {
     /// - Parameter targetDisplayMode: DLABDisplayMode
     /// - Returns: CMTimeScale
     public func nativeTimescaleFor(_ targetDisplayMode:DLABDisplayMode) -> CMTimeScale? {
-        let mode2scale :[DLABDisplayMode:CMTimeScale] = [
-            .modeNTSC           :30000,
-            .modeNTSC2398       :24000,
-            .modeNTSCp          :60000,
-            .modePAL            :25000,
-            .modePALp           :50000,
-            
-            .modeHD720p50       :50000,
-            .modeHD720p5994     :60000,
-            .modeHD720p60       :60000,
-            
-            .modeHD1080p2398    :24000,
-            .modeHD1080p24      :24000,
-            
-            .modeHD1080p25      :25000,
-            .modeHD1080p2997    :30000,
-            .modeHD1080p30      :30000,
-            
-            .modeHD1080p4795    :48000,
-            .modeHD1080p48      :48000,
-            
-            .modeHD1080i50      :25000,
-            .modeHD1080i5994    :30000,
-            .modeHD1080i6000    :30000,
-            
-            .modeHD1080p50      :50000,
-            .modeHD1080p5994    :60000,
-            .modeHD1080p6000    :60000,
-            
-            .modeHD1080p9590    :96000,
-            .modeHD1080p96      :96000,
-            .modeHD1080p100     :100000,
-            .modeHD1080p11988   :120000,
-            .modeHD1080p120     :120000,
-            
-            .mode2k2398         :24000,
-            .mode2k24           :24000,
-            .mode2k25           :25000,
-            
-            .mode2kDCI2398      :24000,
-            .mode2kDCI24        :24000,
-            .mode2kDCI25        :25000,
-            .mode2kDCI2997      :30000,
-            .mode2kDCI30        :30000,
-            .mode2kDCI4795      :48000,
-            .mode2kDCI48        :48000,
-            .mode2kDCI50        :50000,
-            .mode2kDCI5994      :60000,
-            .mode2kDCI60        :60000,
-            .mode2kDCI9590      :96000,
-            .mode2kDCI96        :96000,
-            .mode2kDCI100       :100000,
-            .mode2kDCI11988     :120000,
-            .mode2kDCI120       :120000,
-            
-            .mode4K2160p2398    :24000,
-            .mode4K2160p24      :24000,
-            .mode4K2160p25      :25000,
-            .mode4K2160p2997    :30000,
-            .mode4K2160p30      :30000,
-            .mode4K2160p4795    :48000,
-            .mode4K2160p48      :48000,
-            .mode4K2160p50      :50000,
-            .mode4K2160p5994    :60000,
-            .mode4K2160p60      :60000,
-            .mode4K2160p9590    :96000,
-            .mode4K2160p96      :96000,
-            .mode4K2160p100     :100000,
-            .mode4K2160p11988   :120000,
-            .mode4K2160p120     :120000,
-            
-            .mode4kDCI2398      :24000,
-            .mode4kDCI24        :24000,
-            .mode4kDCI25        :25000,
-            .mode4kDCI2997      :30000,
-            .mode4kDCI30        :30000,
-            .mode4kDCI4795      :48000,
-            .mode4kDCI48        :48000,
-            .mode4kDCI50        :50000,
-            .mode4kDCI5994      :60000,
-            .mode4kDCI60        :60000,
-            .mode4kDCI9590      :96000,
-            .mode4kDCI96        :96000,
-            .mode4kDCI100       :100000,
-            .mode4kDCI11988     :120000,
-            .mode4kDCI120       :120000,
-            
-            // TODO .mode8K...
-        ]
-        
-        if let timeScale = mode2scale[targetDisplayMode] {
-            return timeScale
-        }
-        return nil
+        Self.displayModeTiming[targetDisplayMode]?.timescale
     }
     
     /// Native video frame rate for DisplayMode
     /// - Parameter targetDisplayMode: DLABDisplayMode
     /// - Returns: FPS in Float
     public func nativeFPSFor(_ targetDisplayMode:DLABDisplayMode) -> Float? {
-        let mode2fps :[DLABDisplayMode:Float] = [
-            .modeNTSC           :30.0/1.001,
-            .modeNTSC2398       :30.0/1.001,
-            .modeNTSCp          :60.0/1.001,
-            .modePAL            :25.0,
-            .modePALp           :50.0,
-            
-            .modeHD720p50       :50.0,
-            .modeHD720p5994     :60.0/1.001,
-            .modeHD720p60       :60.0,
-            
-            .modeHD1080p2398    :24.0/1.001,
-            .modeHD1080p24      :24.0,
-            
-            .modeHD1080p25      :25.0,
-            .modeHD1080p2997    :30.0/1.001,
-            .modeHD1080p30      :30.0,
-            
-            .modeHD1080p4795    :48.0/1.001,
-            .modeHD1080p48      :48.0,
-            
-            .modeHD1080i50      :25.0,
-            .modeHD1080i5994    :30.0/1.001,
-            .modeHD1080i6000    :30.0,
-            
-            .modeHD1080p50      :50.0,
-            .modeHD1080p5994    :60.0/1.001,
-            .modeHD1080p6000    :60.0,
-            
-            .modeHD1080p9590    :96.0/1.001,
-            .modeHD1080p96      :96.0,
-            .modeHD1080p100     :100.0,
-            .modeHD1080p11988   :120.0/1.001,
-            .modeHD1080p120     :120.0,
-            
-            .mode2k2398         :24.0/1.001,
-            .mode2k24           :24.0,
-            .mode2k25           :25.0,
-            
-            .mode2kDCI2398      :24.0/1.001,
-            .mode2kDCI24        :24.0,
-            .mode2kDCI25        :25.0,
-            .mode2kDCI2997      :30.0/1.001,
-            .mode2kDCI30        :30.0,
-            .mode2kDCI4795      :48.0/1.001,
-            .mode2kDCI48        :48.0,
-            .mode2kDCI50        :50.0,
-            .mode2kDCI5994      :60.0/1.001,
-            .mode2kDCI60        :60.0,
-            .mode2kDCI9590      :96.0/1.001,
-            .mode2kDCI96        :96.0,
-            .mode2kDCI100       :100.0,
-            .mode2kDCI11988     :120.0/1.001,
-            .mode2kDCI120       :120.0,
-            
-            .mode4K2160p2398    :24.0/1.001,
-            .mode4K2160p24      :24.0,
-            .mode4K2160p25      :25.0,
-            .mode4K2160p2997    :30.0/1.001,
-            .mode4K2160p30      :30.0,
-            .mode4K2160p4795    :48.0/1.001,
-            .mode4K2160p48      :48.0,
-            .mode4K2160p50      :50.0,
-            .mode4K2160p5994    :60.0/1.001,
-            .mode4K2160p60      :60.0,
-            .mode4K2160p9590    :96.0/1.001,
-            .mode4K2160p96      :96.0,
-            .mode4K2160p100     :100.0,
-            .mode4K2160p11988   :120.0/1.001,
-            .mode4K2160p120     :120.0,
-            
-            .mode4kDCI2398      :24.0/1.001,
-            .mode4kDCI24        :24.0,
-            .mode4kDCI25        :25.0,
-            .mode4kDCI2997      :30.0/1.001,
-            .mode4kDCI30        :30.0,
-            .mode4kDCI4795      :48.0/1.001,
-            .mode4kDCI48        :48.0,
-            .mode4kDCI50        :50.0,
-            .mode4kDCI5994      :60.0/1.001,
-            .mode4kDCI60        :60.0,
-            .mode4kDCI9590      :96.0/1.001,
-            .mode4kDCI96        :96.0,
-            .mode4kDCI100       :100.0,
-            .mode4kDCI11988     :120.0/1.001,
-            .mode4kDCI120       :120.0,
-            
-            // TODO .mode8K...
-        ]
-        
-        if let fps = mode2fps[targetDisplayMode] {
-            return fps
-        }
-        return nil
+        Self.displayModeTiming[targetDisplayMode]?.fps
     }
     
     /// Supported DLABDisplayMode list

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -1113,13 +1113,11 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         of sender: DLABDevice
     ) {
         guard sender === currentDevice else { return }
+        guard verbose else { return }
         let modeName = videoSetting?.name ?? "nil"
-        Task { [weak self] in
-            guard let self else { return }
-            self.printVerbose(
-                "NOTICE: CaptureManager.processInputFormatChange - displayMode=\(modeName) events=0x\(String(events.rawValue, radix: 16)) flags=0x\(String(flags.rawValue, radix: 16))"
-            )
-        }
+        print(
+            "NOTICE: CaptureManager.processInputFormatChange - displayMode=\(modeName) events=0x\(String(events.rawValue, radix: 16)) flags=0x\(String(flags.rawValue, radix: 16))"
+        )
     }
     
     /// Callback method implementation - DLABInputCaptureDelegate

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -102,6 +102,14 @@ private final class BoundedWorkQueue: @unchecked Sendable {
     }
 }
 
+private final class WeakParentViewBox: @unchecked Sendable {
+    weak var view: NSView?
+
+    init(view: NSView?) {
+        self.view = view
+    }
+}
+
 /// Extension to make CaptureManager conform to Sendable for cross-actor usage.
 ///
 /// Concurrency model — mutable state falls into these categories:
@@ -283,18 +291,18 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     /// Expected to be read/written on the `@MainActor`.
     public weak var parentView: NSView? = nil {
         didSet {
-            let requestedParentView = parentView
+            let requestedParentView = WeakParentViewBox(view: parentView)
             parentViewUpdateTask?.cancel()
             parentViewUpdateTask = Task { @MainActor [weak self] in
-                guard !Task.isCancelled, let self, let device = currentDevice else { return }
+                guard !Task.isCancelled, let self, let device = self.currentDevice else { return }
                 do {
-                    if let view = requestedParentView {
+                    if let view = requestedParentView.view {
                         try device.setInputScreenPreviewTo(view)
                     } else {
                         try device.setInputScreenPreviewTo(nil)
                     }
                 } catch let error as NSError {
-                    printVerbose("ERROR:\(error.domain)(\(error.code)): \(error.localizedFailureReason ?? "unknown reason")")
+                    self.printVerbose("ERROR:\(error.domain)(\(error.code)): \(error.localizedFailureReason ?? "unknown reason")")
                 }
             }
         }

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -152,6 +152,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     private let videoQueue = BoundedWorkQueue(maxDepth: 4)
     private var audioProcessorTask: Task<Void, Never>?
     private var videoProcessorTask: Task<Void, Never>?
+    private var parentViewUpdateTask: Task<Void, Never>?
     
     /* ============================================ */
     // MARK: - properties - Lock-protected runtime state
@@ -282,11 +283,13 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     /// Expected to be read/written on the `@MainActor`.
     public weak var parentView: NSView? = nil {
         didSet {
-            Task { @MainActor in
-                guard let device = currentDevice else { return }
+            let requestedParentView = parentView
+            parentViewUpdateTask?.cancel()
+            parentViewUpdateTask = Task { @MainActor [weak self] in
+                guard !Task.isCancelled, let self, let device = currentDevice else { return }
                 do {
-                    if let parentView = parentView {
-                        try device.setInputScreenPreviewTo(parentView)
+                    if let view = requestedParentView {
+                        try device.setInputScreenPreviewTo(view)
                     } else {
                         try device.setInputScreenPreviewTo(nil)
                     }

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -1116,7 +1116,9 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         let modeName = videoSetting?.name ?? "nil"
         Task { [weak self] in
             guard let self else { return }
-            printVerbose("NOTICE: CaptureManager.processInputFormatChange - displayMode=\(modeName)")
+            printVerbose(
+                "NOTICE: CaptureManager.processInputFormatChange - displayMode=\(modeName) events=0x\(String(events.rawValue, radix: 16)) flags=0x\(String(flags.rawValue, radix: 16))"
+            )
         }
     }
     

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -1116,7 +1116,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         let modeName = videoSetting?.name ?? "nil"
         Task { [weak self] in
             guard let self else { return }
-            printVerbose(
+            self.printVerbose(
                 "NOTICE: CaptureManager.processInputFormatChange - displayMode=\(modeName) events=0x\(String(events.rawValue, radix: 16)) flags=0x\(String(flags.rawValue, radix: 16))"
             )
         }

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -1111,6 +1111,23 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     /* ============================================ */
     
     /// Callback method implementation - DLABInputCaptureDelegate
+    /// - Note: Automatic format reconfiguration is not supported.
+    ///   Events are logged for diagnostics but no state is changed.
+    public nonisolated func processInputFormatChange(
+        with videoSetting: DLABVideoSetting?,
+        events: DLABVideoInputFormatChangedEvent,
+        flags: DLABDetectedVideoInputFormatFlag,
+        of sender: DLABDevice
+    ) {
+        guard sender === currentDevice else { return }
+        let modeName = videoSetting?.name ?? "nil"
+        Task { [weak self] in
+            guard let self else { return }
+            printVerbose("NOTICE: CaptureManager.processInputFormatChange - displayMode=\(modeName)")
+        }
+    }
+    
+    /// Callback method implementation - DLABInputCaptureDelegate
     /// - Parameters:
     ///   - sampleBuffer: CMSampleBuffer
     ///   - sender: DLABDevice

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -955,16 +955,6 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         try device.setInputScreenPreviewTo(parentView)
     }
     
-    private func createError(_ status :OSStatus, _ description :String?, _ failureReason :String?) -> NSError {
-        let domain = "com.MyCometG3.DLABCaptureManager.ErrorDomain"
-        let code = NSInteger(status)
-        let desc = description ?? "unknown description"
-        let reason = failureReason ?? "unknown failureReason"
-        let userInfo :[String:Any] = [NSLocalizedDescriptionKey:desc,
-                               NSLocalizedFailureReasonErrorKey:reason]
-        return NSError(domain: domain, code: code, userInfo: userInfo)
-    }
-    
     private func applyInputAncillaryPacketHandler(to device: DLABDevice) {
         device.inputAncillaryPacketHandler = inputAncillaryPacketHandler
     }

--- a/Sources/DLABCapture/CaptureTimecodeHelper.swift
+++ b/Sources/DLABCapture/CaptureTimecodeHelper.swift
@@ -202,11 +202,6 @@ class CaptureTimecodeHelper: NSObject {
             frameNumber64 = -frameNumber64
         }
         
-        guard let frameNumber32 = Int32(exactly: frameNumber64) else {
-            print("ERROR: Could not represent frame number in Int32 (\(frameNumber64)).")
-            return nil
-        }
-        
         /* ============================================ */
         
         // Allocate BlockBuffer
@@ -228,6 +223,10 @@ class CaptureTimecodeHelper: NSObject {
         if let dataBuffer = dataBuffer {
             switch sizes {
             case MemoryLayout<Int32>.size:
+                guard let frameNumber32 = Int32(exactly: frameNumber64) else {
+                    print("ERROR: Could not represent frame number in Int32 (\(frameNumber64)).")
+                    return nil
+                }
                 var frameNumber32BE = frameNumber32.bigEndian
                 status = CMBlockBufferReplaceDataBytes(with: &frameNumber32BE,
                                                        blockBuffer: dataBuffer,
@@ -249,5 +248,12 @@ class CaptureTimecodeHelper: NSObject {
         }
         
         return dataBuffer
+    }
+
+    internal func testingPrepareTimeCodeDataBuffer(_ smpteTime: CVSMPTETime,
+                                                   sizes: Int,
+                                                   quanta: UInt32,
+                                                   tcType: UInt32) -> CMBlockBuffer? {
+        prepareTimeCodeDataBuffer(smpteTime, sizes, quanta, tcType)
     }
 }

--- a/Sources/DLABCapture/CaptureTimecodeHelper.swift
+++ b/Sources/DLABCapture/CaptureTimecodeHelper.swift
@@ -202,8 +202,10 @@ class CaptureTimecodeHelper: NSObject {
             frameNumber64 = -frameNumber64
         }
         
-        // TODO
-        let frameNumber32: Int32 = Int32(frameNumber64)
+        guard let frameNumber32 = Int32(exactly: frameNumber64) else {
+            print("ERROR: Could not represent frame number in Int32 (\(frameNumber64)).")
+            return nil
+        }
         
         /* ============================================ */
         

--- a/Sources/DLABCapture/CaptureWriter.swift
+++ b/Sources/DLABCapture/CaptureWriter.swift
@@ -1215,7 +1215,7 @@ actor CaptureWriter: NSObject {
             .failed     : "AVAssetWriterStatus.Failed",
             .cancelled  : "AVAssetWriterStatus.Cancelled"
         ]
-        let statusStr :String = statusArray[status]!
+        let statusStr = statusArray[status] ?? "Unknown(\(status.rawValue))"
         
         return statusStr
     }

--- a/Sources/DLABCapture/CaptureWriter.swift
+++ b/Sources/DLABCapture/CaptureWriter.swift
@@ -1181,13 +1181,6 @@ actor CaptureWriter: NSObject {
     // MARK: -
     /* ============================================ */
     
-    /// Check if the given format ID is part of the AAC family.
-    /// - Parameter formatID: The AudioFormatID to check
-    /// - Returns: true if the format ID is part of the AAC family, false otherwise
-    private func isAACFamily(_ formatID: UInt32) -> Bool {
-        return (formatID >= kAudioFormatMPEG4AAC && formatID <= kAudioFormatMPEG4AAC_HE_V2)
-    }
-    
     /// AAC encoder bitrate range
     private func queryBitrateRange<T: BinaryInteger>(channelCount: T) -> (min: T, max: T) {
         precondition(channelCount > 0, "Channel count must be positive")

--- a/Tests/DLABCaptureTests/DLABCaptureTests.swift
+++ b/Tests/DLABCaptureTests/DLABCaptureTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import CoreMedia
 @testable import DLABCapture
 
 final class DLABCaptureTests: XCTestCase {
@@ -34,6 +35,33 @@ final class DLABCaptureTests: XCTestCase {
         XCTAssertEqual(manager.nativeTimescaleFor(.modeNTSC2398), 24000)
         let fps = try XCTUnwrap(manager.nativeFPSFor(.modeNTSC2398))
         XCTAssertEqual(fps, Float(24.0 / 1.001), accuracy: 0.0001)
+    }
+
+    func testCaptureTimecodeHelperAllowsLargeFrameNumbersForTimeCode64() throws {
+        let helper = CaptureTimecodeHelper(formatType: kCMTimeCodeFormatType_TimeCode64)
+        var smpteTime = CVSMPTETime()
+        smpteTime.type = 0
+        smpteTime.hours = 24_856
+
+        let dataBuffer = try XCTUnwrap(
+            helper.testingPrepareTimeCodeDataBuffer(
+                smpteTime,
+                sizes: MemoryLayout<Int64>.size,
+                quanta: 24,
+                tcType: 0
+            )
+        )
+
+        var encodedFrameNumberBE: Int64 = 0
+        let status = CMBlockBufferCopyDataBytes(
+            dataBuffer,
+            atOffset: 0,
+            dataLength: MemoryLayout<Int64>.size,
+            destination: &encodedFrameNumberBE
+        )
+
+        XCTAssertEqual(status, kCMBlockBufferNoErr)
+        XCTAssertEqual(Int64(bigEndian: encodedFrameNumberBE), 2_147_558_400)
     }
 
     func testCaptureManagerPrewarmRequiresRunningCapture() async throws {

--- a/Tests/DLABCaptureTests/DLABCaptureTests.swift
+++ b/Tests/DLABCaptureTests/DLABCaptureTests.swift
@@ -32,7 +32,8 @@ final class DLABCaptureTests: XCTestCase {
     func testCaptureManagerNativeTimingForNTSC2398() throws {
         let manager = CaptureManager()
 
-        XCTAssertEqual(manager.nativeTimescaleFor(.modeNTSC2398), 24000)
+        let timescale = try XCTUnwrap(manager.nativeTimescaleFor(.modeNTSC2398))
+        XCTAssertEqual(timescale, 24000)
         let fps = try XCTUnwrap(manager.nativeFPSFor(.modeNTSC2398))
         XCTAssertEqual(fps, Float(24.0 / 1.001), accuracy: 0.0001)
     }

--- a/Tests/DLABCaptureTests/DLABCaptureTests.swift
+++ b/Tests/DLABCaptureTests/DLABCaptureTests.swift
@@ -65,6 +65,22 @@ final class DLABCaptureTests: XCTestCase {
         XCTAssertEqual(Int64(bigEndian: encodedFrameNumberBE), 2_147_558_400)
     }
 
+    func testCaptureTimecodeHelperRejectsLargeFrameNumbersForTimeCode32() throws {
+        let helper = CaptureTimecodeHelper(formatType: kCMTimeCodeFormatType_TimeCode32)
+        var smpteTime = CVSMPTETime()
+        smpteTime.type = 0
+        smpteTime.hours = 24_856
+
+        let dataBuffer = helper.testingPrepareTimeCodeDataBuffer(
+            smpteTime,
+            sizes: MemoryLayout<Int32>.size,
+            quanta: 24,
+            tcType: 0
+        )
+
+        XCTAssertNil(dataBuffer)
+    }
+
     func testCaptureManagerPrewarmRequiresRunningCapture() async throws {
         let manager = CaptureManager()
 

--- a/Tests/DLABCaptureTests/DLABCaptureTests.swift
+++ b/Tests/DLABCaptureTests/DLABCaptureTests.swift
@@ -28,6 +28,14 @@ final class DLABCaptureTests: XCTestCase {
         XCTAssertNotNil(manager.findFirstDevice())
     }
 
+    func testCaptureManagerNativeTimingForNTSC2398() throws {
+        let manager = CaptureManager()
+
+        XCTAssertEqual(manager.nativeTimescaleFor(.modeNTSC2398), 24000)
+        let fps = try XCTUnwrap(manager.nativeFPSFor(.modeNTSC2398))
+        XCTAssertEqual(fps, Float(24.0 / 1.001), accuracy: 0.0001)
+    }
+
     func testCaptureManagerPrewarmRequiresRunningCapture() async throws {
         let manager = CaptureManager()
 


### PR DESCRIPTION
Seven reviewed medium-priority fixes from the wave-2 review:

- **parentView update task race mitigation** — cancel previous task before launching new one (M4)
- **status description fallback** — replace force-unwrap with nil-coalescing (M2)
- **checked Int64→Int32 timecode conversion** — use `Int32(exactly:)` with nil guard (M10)
- **input format change logging stub** — explicit non-silent callback implementation (M8)
- **AAC family helper deduplication** — single `isAACFamily` in AACFamilyHelper.swift (M6)
- **createError helper deduplication** — single `createError` in CaptureErrorHelper.swift (M7)
- **display-mode timing table consolidation** — shared `DisplayModeTiming` struct (M9)

Validation: `swift build` and `swift test` pass (25 tests, 0 failures).