### PR TITLE
Fix audio preview lifetime race in CaptureManager

### DIFF
--- a/Sources/DLABCapture/CaptureAudioPreview.swift
+++ b/Sources/DLABCapture/CaptureAudioPreview.swift
@@ -89,7 +89,7 @@ class CaptureAudioPreview: NSObject, @unchecked Sendable {
     ///
     /// - Parameter audioFormatDescription: CMAudioFormatDescription
     /// - Returns: AudioPreview Object if success, nil if failed.
-    internal override init() {
+    fileprivate override init() {
         super.init()
     }
 
@@ -192,6 +192,18 @@ class CaptureAudioPreview: NSObject, @unchecked Sendable {
         }
         
         // print("AudioPreview.init")
+    }
+
+    internal final class TestingDouble: CaptureAudioPreview, @unchecked Sendable {
+        internal override init() {
+            super.init()
+        }
+
+        internal override func aqStop() throws {
+        }
+
+        internal override func aqDispose() throws {
+        }
     }
     
     deinit {

--- a/Sources/DLABCapture/CaptureAudioPreview.swift
+++ b/Sources/DLABCapture/CaptureAudioPreview.swift
@@ -89,6 +89,10 @@ class CaptureAudioPreview: NSObject, @unchecked Sendable {
     ///
     /// - Parameter audioFormatDescription: CMAudioFormatDescription
     /// - Returns: AudioPreview Object if success, nil if failed.
+    internal override init() {
+        super.init()
+    }
+
     init?(_ audioFormatDescription :CMAudioFormatDescription) {
         super.init()
         

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -126,6 +126,15 @@ private struct AudioPreviewDisposeFailure: LocalizedError {
     }
 }
 
+private final class AudioPreviewState: @unchecked Sendable {
+    let preview: CaptureAudioPreview
+    let inFlight = DispatchGroup()
+
+    init(preview: CaptureAudioPreview) {
+        self.preview = preview
+    }
+}
+
 /// Extension to make CaptureManager conform to Sendable for cross-actor usage.
 ///
 /// Concurrency model — mutable state falls into these categories:
@@ -248,27 +257,24 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     }
     /// AudioPreview object
     private let audioPreviewLock = UnfairLockBox()
-    private var audioPreviewStorage: CaptureAudioPreview? = nil
-    private var previewDisposed: Bool = false
-    private let audioPreviewInFlight = DispatchGroup()
+    private var audioPreviewState: AudioPreviewState? = nil
     private let audioPreviewTeardownQueue = DispatchQueue(label: "captureManager.audioPreviewTeardown")
     
     @discardableResult
     private func withAudioPreview<T>(_ body: (CaptureAudioPreview) throws -> T) rethrows -> T? {
-        let preview: CaptureAudioPreview? = audioPreviewLock.withLock {
-            guard !previewDisposed, let preview = audioPreviewStorage else { return nil }
-            audioPreviewInFlight.enter()
-            return preview
+        let state: AudioPreviewState? = audioPreviewLock.withLock {
+            guard let state = audioPreviewState else { return nil }
+            state.inFlight.enter()
+            return state
         }
-        guard let preview else { return nil }
-        defer { audioPreviewInFlight.leave() }
-        return try body(preview)
+        guard let state else { return nil }
+        defer { state.inFlight.leave() }
+        return try body(state.preview)
     }
     
     private func setAudioPreview(_ preview: CaptureAudioPreview?) {
         audioPreviewLock.withLock {
-            audioPreviewStorage = preview
-            previewDisposed = false
+            audioPreviewState = preview.map(AudioPreviewState.init)
         }
     }
     
@@ -301,37 +307,34 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         }
     }
 
-    private func takeAudioPreviewForDisposal() -> CaptureAudioPreview? {
-        audioPreviewLock.withLock { () -> CaptureAudioPreview? in
-            previewDisposed = true
-            let preview = audioPreviewStorage
-            audioPreviewStorage = nil
-            return preview
+    private func takeAudioPreviewForDisposal() -> AudioPreviewState? {
+        audioPreviewLock.withLock { () -> AudioPreviewState? in
+            let state = audioPreviewState
+            audioPreviewState = nil
+            return state
         }
     }
 
     private func finishDisposingAudioPreview(
-        _ preview: CaptureAudioPreview,
+        _ state: AudioPreviewState,
         teardown: @escaping @Sendable (CaptureAudioPreview) throws -> Void
     ) async throws {
         try await Self.finishDisposingAudioPreview(
-            preview,
-            inFlight: audioPreviewInFlight,
+            state,
             teardownQueue: audioPreviewTeardownQueue,
             teardown: teardown
         )
     }
 
     private static func finishDisposingAudioPreview(
-        _ preview: CaptureAudioPreview,
-        inFlight: DispatchGroup,
+        _ state: AudioPreviewState,
         teardownQueue: DispatchQueue,
         teardown: @escaping @Sendable (CaptureAudioPreview) throws -> Void
     ) async throws {
         try await withCheckedThrowingContinuation { continuation in
-            inFlight.notify(queue: teardownQueue) {
+            state.inFlight.notify(queue: teardownQueue) {
                 do {
-                    try teardown(preview)
+                    try teardown(state.preview)
                     continuation.resume()
                 } catch {
                     continuation.resume(throwing: error)
@@ -341,8 +344,8 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     }
 
     private func disposeAudioPreview() async throws {
-        guard let preview = takeAudioPreviewForDisposal() else { return }
-        try await finishDisposingAudioPreview(preview, teardown: Self.teardownAudioPreview)
+        guard let state = takeAudioPreviewForDisposal() else { return }
+        try await finishDisposingAudioPreview(state, teardown: Self.teardownAudioPreview)
     }
 
     internal func testingSetAudioPreview(_ preview: CaptureAudioPreview?) {
@@ -358,12 +361,12 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         didTakePreview: (@Sendable () -> Void)? = nil,
         teardown: @escaping @Sendable (CaptureAudioPreview) throws -> Void
     ) async throws {
-        guard let preview = takeAudioPreviewForDisposal() else {
+        guard let state = takeAudioPreviewForDisposal() else {
             didTakePreview?()
             return
         }
         didTakePreview?()
-        try await finishDisposingAudioPreview(preview, teardown: teardown)
+        try await finishDisposingAudioPreview(state, teardown: teardown)
     }
     /* ============================================ */
     // MARK: - properties - Capturing video (set before capture)
@@ -1000,7 +1003,6 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         let videoPreview = self.videoPreview
         let parentView = self.parentView
         let audioPreview = takeAudioPreviewForDisposal()
-        let audioPreviewInFlight = self.audioPreviewInFlight
         let audioPreviewTeardownQueue = self.audioPreviewTeardownQueue
         let isRecording = self.recording
         let isVideoCaptureEnabled = self.videoCaptureEnabled
@@ -1015,7 +1017,6 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                 do {
                     try await Self.finishDisposingAudioPreview(
                         audioPreview,
-                        inFlight: audioPreviewInFlight,
                         teardownQueue: audioPreviewTeardownQueue,
                         teardown: Self.teardownAudioPreview
                     )

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -251,6 +251,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     private var audioPreviewStorage: CaptureAudioPreview? = nil
     private var previewDisposed: Bool = false
     private let audioPreviewInFlight = DispatchGroup()
+    private let audioPreviewTeardownQueue = DispatchQueue(label: "captureManager.audioPreviewTeardown")
     
     @discardableResult
     private func withAudioPreview<T>(_ body: (CaptureAudioPreview) throws -> T) rethrows -> T? {
@@ -271,15 +272,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         }
     }
     
-    private func disposeAudioPreview() throws {
-        let preview = audioPreviewLock.withLock { () -> CaptureAudioPreview? in
-            previewDisposed = true
-            let preview = audioPreviewStorage
-            audioPreviewStorage = nil
-            return preview
-        }
-        guard let preview else { return }
-        audioPreviewInFlight.wait()
+    private static func teardownAudioPreview(_ preview: CaptureAudioPreview) throws {
         let stopError: NSError?
         do {
             try preview.aqStop()
@@ -306,6 +299,66 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         case let (stopError?, disposeError?):
             throw AudioPreviewDisposeFailure(stopError: stopError, disposeError: disposeError)
         }
+    }
+
+    private func takeAudioPreviewForDisposal() -> CaptureAudioPreview? {
+        audioPreviewLock.withLock { () -> CaptureAudioPreview? in
+            previewDisposed = true
+            let preview = audioPreviewStorage
+            audioPreviewStorage = nil
+            return preview
+        }
+    }
+
+    private func finishDisposingAudioPreview(
+        _ preview: CaptureAudioPreview,
+        teardown: @escaping @Sendable (CaptureAudioPreview) throws -> Void
+    ) async throws {
+        try await Self.finishDisposingAudioPreview(
+            preview,
+            inFlight: audioPreviewInFlight,
+            teardownQueue: audioPreviewTeardownQueue,
+            teardown: teardown
+        )
+    }
+
+    private static func finishDisposingAudioPreview(
+        _ preview: CaptureAudioPreview,
+        inFlight: DispatchGroup,
+        teardownQueue: DispatchQueue,
+        teardown: @escaping @Sendable (CaptureAudioPreview) throws -> Void
+    ) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            inFlight.notify(queue: teardownQueue) {
+                do {
+                    try teardown(preview)
+                    continuation.resume()
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    private func disposeAudioPreview() async throws {
+        guard let preview = takeAudioPreviewForDisposal() else { return }
+        try await finishDisposingAudioPreview(preview, teardown: Self.teardownAudioPreview)
+    }
+
+    internal func testingSetAudioPreview(_ preview: CaptureAudioPreview?) {
+        setAudioPreview(preview)
+    }
+
+    @discardableResult
+    internal func testingWithAudioPreview<T>(_ body: (CaptureAudioPreview) throws -> T) rethrows -> T? {
+        try withAudioPreview(body)
+    }
+
+    internal func testingDisposeAudioPreview(
+        teardown: @escaping @Sendable (CaptureAudioPreview) throws -> Void
+    ) async throws {
+        guard let preview = takeAudioPreviewForDisposal() else { return }
+        try await finishDisposingAudioPreview(preview, teardown: teardown)
     }
     /* ============================================ */
     // MARK: - properties - Capturing video (set before capture)
@@ -781,7 +834,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                 if let _ = parentView {
                     try await attachInputScreenPreview(to: nil) // @MainActor
                 }
-                try disposeAudioPreview()
+                try await disposeAudioPreview()
                 
                 // support for timecode
                 timecodeReady = false
@@ -937,21 +990,13 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         // Copy actor isolated properties to nonisolated variables
         let verbose = self.verbose
         
-        do { try disposeAudioPreview() }
-        catch let error as AudioPreviewDisposeFailure {
-            if verbose {
-                print("ERROR:CaptureManager.detachedCleanup - aqStop failed: \(error.stopError.domain)(\(error.stopError.code)): \(error.stopError.localizedFailureReason ?? error.stopError.localizedDescription)")
-                print("ERROR:CaptureManager.detachedCleanup - aqDispose failed: \(error.disposeError.domain)(\(error.disposeError.code)): \(error.disposeError.localizedFailureReason ?? error.disposeError.localizedDescription)")
-            }
-        }
-        catch let error as NSError {
-            if verbose { print("ERROR:CaptureManager.detachedCleanup - disposeAudioPreview failed: \(error.domain)(\(error.code)): \(error.localizedFailureReason ?? error.localizedDescription)") }
-        }
-        
         let device = self.currentDevice
         let writer = self.writer
         let videoPreview = self.videoPreview
         let parentView = self.parentView
+        let audioPreview = takeAudioPreviewForDisposal()
+        let audioPreviewInFlight = self.audioPreviewInFlight
+        let audioPreviewTeardownQueue = self.audioPreviewTeardownQueue
         let isRecording = self.recording
         let isVideoCaptureEnabled = self.videoCaptureEnabled
         let isAudioCaptureEnabled = self.audioCaptureEnabled
@@ -960,6 +1005,24 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         Task.detached {
             // Avoid capturing self in the deinit task
             if verbose { print("CaptureManager.\(#function) - Task started") }
+
+            if let audioPreview {
+                do {
+                    try await Self.finishDisposingAudioPreview(
+                        audioPreview,
+                        inFlight: audioPreviewInFlight,
+                        teardownQueue: audioPreviewTeardownQueue,
+                        teardown: Self.teardownAudioPreview
+                    )
+                } catch let error as AudioPreviewDisposeFailure {
+                    if verbose {
+                        print("ERROR:CaptureManager.detachedCleanup - aqStop failed: \(error.stopError.domain)(\(error.stopError.code)): \(error.stopError.localizedFailureReason ?? error.stopError.localizedDescription)")
+                        print("ERROR:CaptureManager.detachedCleanup - aqDispose failed: \(error.disposeError.domain)(\(error.disposeError.code)): \(error.disposeError.localizedFailureReason ?? error.disposeError.localizedDescription)")
+                    }
+                } catch let error as NSError {
+                    if verbose { print("ERROR:CaptureManager.detachedCleanup - disposeAudioPreview failed: \(error.domain)(\(error.code)): \(error.localizedFailureReason ?? error.localizedDescription)") }
+                }
+            }
             
             if isRecording, let writer = writer {
                 await writer.closeSession() // actor isolated (writer)

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -110,6 +110,22 @@ private final class WeakParentViewBox: @unchecked Sendable {
     }
 }
 
+private struct AudioPreviewDisposeFailure: LocalizedError {
+    let stopError: NSError
+    let disposeError: NSError
+
+    var errorDescription: String? {
+        "Audio preview teardown failed."
+    }
+
+    var failureReason: String? {
+        [
+            "aqStop: \(stopError.domain)(\(stopError.code)): \(stopError.localizedFailureReason ?? stopError.localizedDescription)",
+            "aqDispose: \(disposeError.domain)(\(disposeError.code)): \(disposeError.localizedFailureReason ?? disposeError.localizedDescription)"
+        ].joined(separator: " | ")
+    }
+}
+
 /// Extension to make CaptureManager conform to Sendable for cross-actor usage.
 ///
 /// Concurrency model — mutable state falls into these categories:
@@ -236,6 +252,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     private var previewDisposed: Bool = false
     private let audioPreviewInFlight = DispatchGroup()
     
+    @discardableResult
     private func withAudioPreview<T>(_ body: (CaptureAudioPreview) throws -> T) rethrows -> T? {
         let preview: CaptureAudioPreview? = audioPreviewLock.withLock {
             guard !previewDisposed, let preview = audioPreviewStorage else { return nil }
@@ -263,8 +280,32 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         }
         guard let preview else { return }
         audioPreviewInFlight.wait()
-        try preview.aqStop()
-        try preview.aqDispose()
+        let stopError: NSError?
+        do {
+            try preview.aqStop()
+            stopError = nil
+        } catch let error as NSError {
+            stopError = error
+        }
+
+        let disposeError: NSError?
+        do {
+            try preview.aqDispose()
+            disposeError = nil
+        } catch let error as NSError {
+            disposeError = error
+        }
+
+        switch (stopError, disposeError) {
+        case (nil, nil):
+            return
+        case let (stopError?, nil):
+            throw stopError
+        case let (nil, disposeError?):
+            throw disposeError
+        case let (stopError?, disposeError?):
+            throw AudioPreviewDisposeFailure(stopError: stopError, disposeError: disposeError)
+        }
     }
     /* ============================================ */
     // MARK: - properties - Capturing video (set before capture)
@@ -897,8 +938,14 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         let verbose = self.verbose
         
         do { try disposeAudioPreview() }
-        catch {
-            if verbose { print("ERROR:CaptureManager.detachedCleanup - disposeAudioPreview failed: \(error.localizedDescription)") }
+        catch let error as AudioPreviewDisposeFailure {
+            if verbose {
+                print("ERROR:CaptureManager.detachedCleanup - aqStop failed: \(error.stopError.domain)(\(error.stopError.code)): \(error.stopError.localizedFailureReason ?? error.stopError.localizedDescription)")
+                print("ERROR:CaptureManager.detachedCleanup - aqDispose failed: \(error.disposeError.domain)(\(error.disposeError.code)): \(error.disposeError.localizedFailureReason ?? error.disposeError.localizedDescription)")
+            }
+        }
+        catch let error as NSError {
+            if verbose { print("ERROR:CaptureManager.detachedCleanup - disposeAudioPreview failed: \(error.domain)(\(error.code)): \(error.localizedFailureReason ?? error.localizedDescription)") }
         }
         
         let device = self.currentDevice

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -213,7 +213,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     public var volume: Float = 1.0 {
         didSet {
             volume = max(0.0, min(1.0, volume))
-            if let preview = currentAudioPreview() {
+            withAudioPreview { preview in
                 preview.volume = Float32(volume)
             }
         }
@@ -234,11 +234,17 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     private let audioPreviewLock = UnfairLockBox()
     private var audioPreviewStorage: CaptureAudioPreview? = nil
     private var previewDisposed: Bool = false
+    private let audioPreviewInFlight = DispatchGroup()
     
-    private func currentAudioPreview() -> CaptureAudioPreview? {
-        audioPreviewLock.withLock {
-            previewDisposed ? nil : audioPreviewStorage
+    private func withAudioPreview<T>(_ body: (CaptureAudioPreview) throws -> T) rethrows -> T? {
+        let preview: CaptureAudioPreview? = audioPreviewLock.withLock {
+            guard !previewDisposed, let preview = audioPreviewStorage else { return nil }
+            audioPreviewInFlight.enter()
+            return preview
         }
+        guard let preview else { return nil }
+        defer { audioPreviewInFlight.leave() }
+        return try body(preview)
     }
     
     private func setAudioPreview(_ preview: CaptureAudioPreview?) {
@@ -248,14 +254,17 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         }
     }
     
-    private func takeAudioPreview() -> CaptureAudioPreview? {
-        audioPreviewLock.withLock {
-            guard !previewDisposed else { return nil }
+    private func disposeAudioPreview() throws {
+        let preview = audioPreviewLock.withLock { () -> CaptureAudioPreview? in
+            previewDisposed = true
             let preview = audioPreviewStorage
             audioPreviewStorage = nil
-            previewDisposed = true
             return preview
         }
+        guard let preview else { return }
+        audioPreviewInFlight.wait()
+        try preview.aqStop()
+        try preview.aqDispose()
     }
     /* ============================================ */
     // MARK: - properties - Capturing video (set before capture)
@@ -731,10 +740,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                 if let _ = parentView {
                     try await attachInputScreenPreview(to: nil) // @MainActor
                 }
-                if let preview = takeAudioPreview() {
-                    try preview.aqStop()
-                    try preview.aqDispose()
-                }
+                try disposeAudioPreview()
                 
                 // support for timecode
                 timecodeReady = false
@@ -890,11 +896,15 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         // Copy actor isolated properties to nonisolated variables
         let verbose = self.verbose
         
+        do { try disposeAudioPreview() }
+        catch {
+            if verbose { print("ERROR:CaptureManager.detachedCleanup - disposeAudioPreview failed: \(error.localizedDescription)") }
+        }
+        
         let device = self.currentDevice
         let writer = self.writer
         let videoPreview = self.videoPreview
         let parentView = self.parentView
-        let audioPreview = takeAudioPreview()
         let isRecording = self.recording
         let isVideoCaptureEnabled = self.videoCaptureEnabled
         let isAudioCaptureEnabled = self.audioCaptureEnabled
@@ -936,16 +946,6 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                         catch {
                             if verbose { print("ERROR:CaptureManager.detachedCleanup - setInputScreenPreviewTo failed: \(error.localizedDescription)") }
                         }
-                    }
-                }
-                if let audioPreview = audioPreview {
-                    do { try audioPreview.aqStop() }
-                    catch {
-                        if verbose { print("ERROR:CaptureManager.detachedCleanup - aqStop failed: \(error.localizedDescription)") }
-                    }
-                    do { try audioPreview.aqDispose() }
-                    catch {
-                        if verbose { print("ERROR:CaptureManager.detachedCleanup - aqDispose failed: \(error.localizedDescription)") }
                     }
                 }
             }
@@ -1195,7 +1195,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                 printVerbose("ERROR:CaptureManager.\(#function) - audio append failed: \(error.localizedDescription)")
             }
         }
-        if let preview = currentAudioPreview() {
+        withAudioPreview { preview in
             if preview.running == true {
                 do { try preview.enqueue(sampleBuffer) }
                 catch {

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -358,14 +358,11 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     }
 
     internal func testingDisposeAudioPreview(
-        didTakePreview: (@Sendable () -> Void)? = nil,
+        didTakeAudioPreviewState: (@Sendable () -> Void)? = nil,
         teardown: @escaping @Sendable (CaptureAudioPreview) throws -> Void
     ) async throws {
-        guard let state = takeAudioPreviewForDisposal() else {
-            didTakePreview?()
-            return
-        }
-        didTakePreview?()
+        guard let state = takeAudioPreviewForDisposal() else { return }
+        didTakeAudioPreviewState?()
         try await finishDisposingAudioPreview(state, teardown: teardown)
     }
     /* ============================================ */
@@ -1002,7 +999,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         let writer = self.writer
         let videoPreview = self.videoPreview
         let parentView = self.parentView
-        let audioPreview = takeAudioPreviewForDisposal()
+        let audioPreviewState = takeAudioPreviewForDisposal()
         let audioPreviewTeardownQueue = self.audioPreviewTeardownQueue
         let isRecording = self.recording
         let isVideoCaptureEnabled = self.videoCaptureEnabled
@@ -1013,10 +1010,10 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
             // Avoid capturing self in the deinit task
             if verbose { print("CaptureManager.\(#function) - Task started") }
 
-            if let audioPreview {
+            if let audioPreviewState {
                 do {
                     try await Self.finishDisposingAudioPreview(
-                        audioPreview,
+                        audioPreviewState,
                         teardownQueue: audioPreviewTeardownQueue,
                         teardown: Self.teardownAudioPreview
                     )

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -355,9 +355,14 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     }
 
     internal func testingDisposeAudioPreview(
+        didTakePreview: (@Sendable () -> Void)? = nil,
         teardown: @escaping @Sendable (CaptureAudioPreview) throws -> Void
     ) async throws {
-        guard let preview = takeAudioPreviewForDisposal() else { return }
+        guard let preview = takeAudioPreviewForDisposal() else {
+            didTakePreview?()
+            return
+        }
+        didTakePreview?()
         try await finishDisposingAudioPreview(preview, teardown: teardown)
     }
     /* ============================================ */

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -1020,7 +1020,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                         print("ERROR:CaptureManager.detachedCleanup - aqDispose failed: \(error.disposeError.domain)(\(error.disposeError.code)): \(error.disposeError.localizedFailureReason ?? error.disposeError.localizedDescription)")
                     }
                 } catch let error as NSError {
-                    if verbose { print("ERROR:CaptureManager.detachedCleanup - disposeAudioPreview failed: \(error.domain)(\(error.code)): \(error.localizedFailureReason ?? error.localizedDescription)") }
+                    if verbose { print("ERROR:CaptureManager.detachedCleanup - audio preview teardown failed: \(error.domain)(\(error.code)): \(error.localizedFailureReason ?? error.localizedDescription)") }
                 }
             }
             

--- a/Tests/DLABCaptureTests/DLABCaptureTests.swift
+++ b/Tests/DLABCaptureTests/DLABCaptureTests.swift
@@ -100,6 +100,7 @@ final class DLABCaptureTests: XCTestCase {
         let manager = CaptureManager()
         let preview = CaptureAudioPreview.TestingDouble()
         let started = expectation(description: "audio preview use started")
+        let disposeStarted = expectation(description: "audio preview disposal started")
         let release = DispatchSemaphore(value: 0)
         let teardownCallCount = CounterBox()
 
@@ -115,12 +116,15 @@ final class DLABCaptureTests: XCTestCase {
         await fulfillment(of: [started], timeout: 1.0)
 
         let disposeTask = Task {
-            try await manager.testingDisposeAudioPreview { _ in
+            try await manager.testingDisposeAudioPreview(didTakePreview: {
+                disposeStarted.fulfill()
+            }) { _ in
                 teardownCallCount.increment()
             }
         }
 
-        try await Task.sleep(nanoseconds: 100_000_000)
+        await fulfillment(of: [disposeStarted], timeout: 1.0)
+        XCTAssertNil(manager.testingWithAudioPreview { _ in () })
         XCTAssertEqual(teardownCallCount.value, 0)
 
         release.signal()

--- a/Tests/DLABCaptureTests/DLABCaptureTests.swift
+++ b/Tests/DLABCaptureTests/DLABCaptureTests.swift
@@ -98,7 +98,7 @@ final class DLABCaptureTests: XCTestCase {
 
     func testCaptureManagerDisposeAudioPreviewWaitsForInFlightUse() async throws {
         let manager = CaptureManager()
-        let preview = CaptureAudioPreview()
+        let preview = CaptureAudioPreview.TestingDouble()
         let started = expectation(description: "audio preview use started")
         let release = DispatchSemaphore(value: 0)
         let teardownCallCount = CounterBox()

--- a/Tests/DLABCaptureTests/DLABCaptureTests.swift
+++ b/Tests/DLABCaptureTests/DLABCaptureTests.swift
@@ -2,6 +2,21 @@ import XCTest
 import CoreMedia
 @testable import DLABCapture
 
+private final class CounterBox: @unchecked Sendable {
+    private let lock = UnfairLockBox()
+    private var valueStorage = 0
+
+    func increment() {
+        lock.withLock {
+            valueStorage += 1
+        }
+    }
+
+    var value: Int {
+        lock.withLock { valueStorage }
+    }
+}
+
 final class DLABCaptureTests: XCTestCase {
     func testCaptureManager() throws {
         XCTAssertNotNil(CaptureManager())
@@ -79,6 +94,40 @@ final class DLABCaptureTests: XCTestCase {
         )
 
         XCTAssertNil(dataBuffer)
+    }
+
+    func testCaptureManagerDisposeAudioPreviewWaitsForInFlightUse() async throws {
+        let manager = CaptureManager()
+        let preview = CaptureAudioPreview()
+        let started = expectation(description: "audio preview use started")
+        let release = DispatchSemaphore(value: 0)
+        let teardownCallCount = CounterBox()
+
+        manager.testingSetAudioPreview(preview)
+
+        DispatchQueue.global().async {
+            _ = manager.testingWithAudioPreview { _ in
+                started.fulfill()
+                _ = release.wait(timeout: .now() + 2.0)
+            }
+        }
+
+        await fulfillment(of: [started], timeout: 1.0)
+
+        let disposeTask = Task {
+            try await manager.testingDisposeAudioPreview { _ in
+                teardownCallCount.increment()
+            }
+        }
+
+        try await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertEqual(teardownCallCount.value, 0)
+
+        release.signal()
+        try await disposeTask.value
+
+        XCTAssertEqual(teardownCallCount.value, 1)
+        XCTAssertNil(manager.testingWithAudioPreview { _ in () })
     }
 
     func testCaptureManagerPrewarmRequiresRunningCapture() async throws {

--- a/Tests/DLABCaptureTests/DLABCaptureTests.swift
+++ b/Tests/DLABCaptureTests/DLABCaptureTests.swift
@@ -116,7 +116,7 @@ final class DLABCaptureTests: XCTestCase {
         await fulfillment(of: [started], timeout: 1.0)
 
         let disposeTask = Task {
-            try await manager.testingDisposeAudioPreview(didTakePreview: {
+            try await manager.testingDisposeAudioPreview(didTakeAudioPreviewState: {
                 disposeStarted.fulfill()
             }) { _ in
                 teardownCallCount.increment()


### PR DESCRIPTION
Replace fetch-then-use audio preview access with a DispatchGroup-based in-flight tracking model to eliminate the TOCTOU race between preview operations and disposal.

- `withAudioPreview(body:)` atomically enters the in-flight group before releasing the lock, preventing racing with disposal
- `disposeAudioPreview()` sets the disposal flag, waits for in-flight ops via `DispatchGroup.wait()`, then stops and disposes
- `captureStopAsync()` uses `try disposeAudioPreview()` inside the existing do-catch — failure still propagates to stopError
- `detachedCleanup()` uses do-catch with verbose logging, preserving existing teardown observability

Call sites: processCapturedAudioSampleAsync, volume.didSet, captureStopAsync, detachedCleanup.

Validation: `swift build` and `swift test` pass (28 tests, 0 failures).