### PR TITLE
Integrate reviewed session fixes into work

### DIFF
--- a/Sources/DLABCapture/CaptureAudioPreview.swift
+++ b/Sources/DLABCapture/CaptureAudioPreview.swift
@@ -92,7 +92,7 @@ class CaptureAudioPreview: NSObject, @unchecked Sendable {
     fileprivate override init() {
         super.init()
     }
-
+    
     init?(_ audioFormatDescription :CMAudioFormatDescription) {
         super.init()
         
@@ -193,15 +193,15 @@ class CaptureAudioPreview: NSObject, @unchecked Sendable {
         
         // print("AudioPreview.init")
     }
-
+    
     internal final class TestingDouble: CaptureAudioPreview, @unchecked Sendable {
         internal override init() {
             super.init()
         }
-
+        
         internal override func aqStop() throws {
         }
-
+        
         internal override func aqDispose() throws {
         }
     }

--- a/Sources/DLABCapture/CaptureAudioPreview.swift
+++ b/Sources/DLABCapture/CaptureAudioPreview.swift
@@ -356,23 +356,21 @@ class CaptureAudioPreview: NSObject, @unchecked Sendable {
         // Prepare audioBufferList from CMSampleBuffer
         var audioBufferList :AudioBufferList = AudioBufferList()
         var blockBuffer :CMBlockBuffer? = nil
-        do {
-            var bufferListSizeNeededOut :Int = 0
-            let sizeOfAudioBufferList = Int(MemoryLayout<AudioBufferList>.size)
-            let alignmentFlag = kCMSampleBufferFlag_AudioBufferList_Assure16ByteAlignment
-            
-            status = CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(sampleBuffer,
-                                                                             bufferListSizeNeededOut: &bufferListSizeNeededOut,
-                                                                             bufferListOut: &audioBufferList,
-                                                                             bufferListSize: sizeOfAudioBufferList,
-                                                                             blockBufferAllocator: kCFAllocatorDefault,
-                                                                             blockBufferMemoryAllocator: kCFAllocatorDefault,
-                                                                             flags: alignmentFlag,
-                                                                             blockBufferOut: &blockBuffer)
-            if status != 0 {
-                //print("ERROR: Failed to get audioBufferList. \(status)")
-                return status
-            }
+        var bufferListSizeNeededOut :Int = 0
+        let sizeOfAudioBufferList = Int(MemoryLayout<AudioBufferList>.size)
+        let alignmentFlag = kCMSampleBufferFlag_AudioBufferList_Assure16ByteAlignment
+        
+        status = CMSampleBufferGetAudioBufferListWithRetainedBlockBuffer(sampleBuffer,
+                                                                         bufferListSizeNeededOut: &bufferListSizeNeededOut,
+                                                                         bufferListOut: &audioBufferList,
+                                                                         bufferListSize: sizeOfAudioBufferList,
+                                                                         blockBufferAllocator: kCFAllocatorDefault,
+                                                                         blockBufferMemoryAllocator: kCFAllocatorDefault,
+                                                                         flags: alignmentFlag,
+                                                                         blockBufferOut: &blockBuffer)
+        if status != 0 {
+            //print("ERROR: Failed to get audioBufferList. \(status)")
+            return status
         }
         
         // Fill AudioQueueBuffer(dst) from AudioBufferList(src)

--- a/Sources/DLABCapture/CaptureErrorHelper.swift
+++ b/Sources/DLABCapture/CaptureErrorHelper.swift
@@ -18,6 +18,6 @@ internal func createError(_ status: OSStatus,
     let desc = description ?? "unknown description"
     let reason = failureReason ?? "unknown failureReason"
     let userInfo: [String: Any] = [NSLocalizedDescriptionKey: desc,
-                                   NSLocalizedFailureReasonErrorKey: reason]
+                            NSLocalizedFailureReasonErrorKey: reason]
     return NSError(domain: errorDomain, code: code, userInfo: userInfo)
 }

--- a/Sources/DLABCapture/CaptureManager+Util.swift
+++ b/Sources/DLABCapture/CaptureManager+Util.swift
@@ -149,23 +149,21 @@ extension CaptureManager {
     /// - Returns: Dictionary
     public func deviceInfo(device :DLABDevice) -> [String:Any] {
         var info :[String:Any] = [:]
-        do {
-            info["modelName"] = device.modelName // NSString* -> String
-            info["displayName"] = device.displayName // NSString* -> String
-            info["persistentID"] = device.persistentID // int64_t -> Int64
-            info["deviceGroupID"] = device.deviceGroupID // int64_t -> Int64
-            info["topologicalID"] = device.topologicalID // int64_t -> Int64
-            info["numberOfSubDevices"] = device.numberOfSubDevices // int64_t -> Int64
-            info["subDeviceIndex"] = device.subDeviceIndex // int64_t -> Int64
-            info["profileID"] = device.profileID // int64_t -> Int64
-            info["duplex"] = device.duplex // int64_t -> Int64
-            info["supportFlag"] = device.supportFlag // uint32_t -> UInt32
-            info["supportCapture"] = device.supportCapture // BOOL
-            info["supportPlayback"] = device.supportPlayback // BOOL
-            info["supportKeying"] = device.supportKeying // BOOL
-            info["supportInputFormatDetection"] = device.supportInputFormatDetection // BOOL
-            info["supportHDRMetadata"] = device.supportHDRMetadata // BOOL
-        }
+        info["modelName"] = device.modelName // NSString* -> String
+        info["displayName"] = device.displayName // NSString* -> String
+        info["persistentID"] = device.persistentID // int64_t -> Int64
+        info["deviceGroupID"] = device.deviceGroupID // int64_t -> Int64
+        info["topologicalID"] = device.topologicalID // int64_t -> Int64
+        info["numberOfSubDevices"] = device.numberOfSubDevices // int64_t -> Int64
+        info["subDeviceIndex"] = device.subDeviceIndex // int64_t -> Int64
+        info["profileID"] = device.profileID // int64_t -> Int64
+        info["duplex"] = device.duplex // int64_t -> Int64
+        info["supportFlag"] = device.supportFlag // uint32_t -> UInt32
+        info["supportCapture"] = device.supportCapture // BOOL
+        info["supportPlayback"] = device.supportPlayback // BOOL
+        info["supportKeying"] = device.supportKeying // BOOL
+        info["supportInputFormatDetection"] = device.supportInputFormatDetection // BOOL
+        info["supportHDRMetadata"] = device.supportHDRMetadata // BOOL
         return info
     }
     
@@ -179,14 +177,12 @@ extension CaptureManager {
     /// - Returns: Dictionary
     public func audioSettingInfo(setting :DLABAudioSetting) -> [String:Any] {
         var info :[String:Any] = [:]
-        do {
-            info["sampleSize"] = setting.sampleSize // uint32_t -> UInt32
-            info["channelCount"] = setting.channelCount // uint32_t -> UInt32
-            info["sampleType"] = setting.sampleType // uint32_t -> UInt32
-            info["sampleRate"] = setting.sampleRate // uint32_t -> UInt32
-            
-            info["audioFormatDescription"] = setting.audioFormatDescription.debugDescription // String
-        }
+        info["sampleSize"] = setting.sampleSize // uint32_t -> UInt32
+        info["channelCount"] = setting.channelCount // uint32_t -> UInt32
+        info["sampleType"] = setting.sampleType // uint32_t -> UInt32
+        info["sampleRate"] = setting.sampleRate // uint32_t -> UInt32
+        
+        info["audioFormatDescription"] = setting.audioFormatDescription.debugDescription // String
         return info
     }
     
@@ -195,30 +191,28 @@ extension CaptureManager {
     /// - Returns: Dictionary
     public func videoSettingInfo(setting :DLABVideoSetting) -> [String:Any] {
         var info :[String:Any] = [:]
-        do {
-            info["name"] = setting.name // NSString* -> String
-            info["width"] = setting.width // long -> int64_t -> Int64
-            info["height"] = setting.height // long -> int64_t -> Int64
-            
-            info["duration"] = setting.duration // int64_t -> Int64
-            info["timeScale"] = setting.timeScale // int64_t -> Int64
-            info["displayMode"] = NSFileTypeForHFSTypeCode(setting.displayMode.rawValue) // Sting
-            info["fieldDominance"] = NSFileTypeForHFSTypeCode(setting.fieldDominance.rawValue) // String
-            info["displayModeFlag"] = setting.displayModeFlag.rawValue // uint32_t -> UInt32
-            info["isHD"] = setting.isHD // BOOL
-            info["useSERIAL"] = setting.useSERIAL // BOOL
-            info["useVITC"] = setting.useVITC // BOOL
-            info["useRP188"] = setting.useRP188 // BOOL
-            
-            info["pixelFormat"] = NSFileTypeForHFSTypeCode(setting.pixelFormat.rawValue) // uint32_t -> UInt32
-            info["inputFlag"] = setting.inputFlag.rawValue // uint32_t -> UInt32
-            info["outputFlag"] = setting.outputFlag.rawValue // uint32_t -> UInt32
-            info["rowBytes"] = setting.rowBytes // long -> int64_t -> Int64
-            info["videoFormatDescription"] = setting.videoFormatDescription.debugDescription // String
-            
-            info["cvPixelFormatType"] = setting.cvPixelFormatType; // UInt32
-            info["cvRowBytes"]  = setting.cvRowBytes; // size_t -> Int -> Int64
-        }
+        info["name"] = setting.name // NSString* -> String
+        info["width"] = setting.width // long -> int64_t -> Int64
+        info["height"] = setting.height // long -> int64_t -> Int64
+        
+        info["duration"] = setting.duration // int64_t -> Int64
+        info["timeScale"] = setting.timeScale // int64_t -> Int64
+        info["displayMode"] = NSFileTypeForHFSTypeCode(setting.displayMode.rawValue) // Sting
+        info["fieldDominance"] = NSFileTypeForHFSTypeCode(setting.fieldDominance.rawValue) // String
+        info["displayModeFlag"] = setting.displayModeFlag.rawValue // uint32_t -> UInt32
+        info["isHD"] = setting.isHD // BOOL
+        info["useSERIAL"] = setting.useSERIAL // BOOL
+        info["useVITC"] = setting.useVITC // BOOL
+        info["useRP188"] = setting.useRP188 // BOOL
+        
+        info["pixelFormat"] = NSFileTypeForHFSTypeCode(setting.pixelFormat.rawValue) // uint32_t -> UInt32
+        info["inputFlag"] = setting.inputFlag.rawValue // uint32_t -> UInt32
+        info["outputFlag"] = setting.outputFlag.rawValue // uint32_t -> UInt32
+        info["rowBytes"] = setting.rowBytes // long -> int64_t -> Int64
+        info["videoFormatDescription"] = setting.videoFormatDescription.debugDescription // String
+        
+        info["cvPixelFormatType"] = setting.cvPixelFormatType; // UInt32
+        info["cvRowBytes"]  = setting.cvRowBytes; // size_t -> Int -> Int64
         return info
     }
     

--- a/Sources/DLABCapture/CaptureManager+Util.swift
+++ b/Sources/DLABCapture/CaptureManager+Util.swift
@@ -124,8 +124,8 @@ extension CaptureManager {
     public func deviceList() -> [DLABDevice]? {
         let browser = DLABBrowser()
         _ = browser.registerDevicesForInput()
-        let devciceList = browser.allDevices
-        return devciceList
+        let deviceList = browser.allDevices
+        return deviceList
     }
     
     /// Supported Input VideoSettings for DLABDevice

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -104,7 +104,7 @@ private final class BoundedWorkQueue: @unchecked Sendable {
 
 private final class WeakParentViewBox: @unchecked Sendable {
     weak var view: NSView?
-
+    
     init(view: NSView?) {
         self.view = view
     }
@@ -113,11 +113,11 @@ private final class WeakParentViewBox: @unchecked Sendable {
 private struct AudioPreviewDisposeFailure: LocalizedError {
     let stopError: NSError
     let disposeError: NSError
-
+    
     var errorDescription: String? {
         "Audio preview teardown failed."
     }
-
+    
     var failureReason: String? {
         [
             "aqStop: \(stopError.domain)(\(stopError.code)): \(stopError.localizedFailureReason ?? stopError.localizedDescription)",
@@ -129,7 +129,7 @@ private struct AudioPreviewDisposeFailure: LocalizedError {
 private final class AudioPreviewState: @unchecked Sendable {
     let preview: CaptureAudioPreview
     let inFlight = DispatchGroup()
-
+    
     init(preview: CaptureAudioPreview) {
         self.preview = preview
     }
@@ -286,7 +286,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         } catch let error as NSError {
             stopError = error
         }
-
+        
         let disposeError: NSError?
         do {
             try preview.aqDispose()
@@ -294,7 +294,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         } catch let error as NSError {
             disposeError = error
         }
-
+        
         switch (stopError, disposeError) {
         case (nil, nil):
             return
@@ -306,7 +306,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
             throw AudioPreviewDisposeFailure(stopError: stopError, disposeError: disposeError)
         }
     }
-
+    
     private func takeAudioPreviewForDisposal() -> AudioPreviewState? {
         audioPreviewLock.withLock { () -> AudioPreviewState? in
             let state = audioPreviewState
@@ -314,7 +314,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
             return state
         }
     }
-
+    
     private func finishDisposingAudioPreview(
         _ state: AudioPreviewState,
         teardown: @escaping @Sendable (CaptureAudioPreview) throws -> Void
@@ -325,7 +325,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
             teardown: teardown
         )
     }
-
+    
     private static func finishDisposingAudioPreview(
         _ state: AudioPreviewState,
         teardownQueue: DispatchQueue,
@@ -342,21 +342,21 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
             }
         }
     }
-
+    
     private func disposeAudioPreview() async throws {
         guard let state = takeAudioPreviewForDisposal() else { return }
         try await finishDisposingAudioPreview(state, teardown: Self.teardownAudioPreview)
     }
-
+    
     internal func testingSetAudioPreview(_ preview: CaptureAudioPreview?) {
         setAudioPreview(preview)
     }
-
+    
     @discardableResult
     internal func testingWithAudioPreview<T>(_ body: (CaptureAudioPreview) throws -> T) rethrows -> T? {
         try withAudioPreview(body)
     }
-
+    
     internal func testingDisposeAudioPreview(
         didTakeAudioPreviewState: (@Sendable () -> Void)? = nil,
         teardown: @escaping @Sendable (CaptureAudioPreview) throws -> Void
@@ -1009,7 +1009,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         Task.detached {
             // Avoid capturing self in the deinit task
             if verbose { print("CaptureManager.\(#function) - Task started") }
-
+            
             if let audioPreviewState {
                 do {
                     try await Self.finishDisposingAudioPreview(

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -1355,9 +1355,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         
         if let videoPreview = videoPreview {
             let wrapper = UnsafeSampleBufferWrapper(sampleBuffer: sampleBuffer)
-            do {
-                await videoPreview.queueSampleBufferAsync(wrapper: wrapper)
-            }
+            await videoPreview.queueSampleBufferAsync(wrapper: wrapper)
         }
         
         if let setting = setting {

--- a/Sources/DLABCapture/CaptureTimecodeHelper.swift
+++ b/Sources/DLABCapture/CaptureTimecodeHelper.swift
@@ -249,7 +249,7 @@ class CaptureTimecodeHelper: NSObject {
         
         return dataBuffer
     }
-
+    
     internal func testingPrepareTimeCodeDataBuffer(_ smpteTime: CVSMPTETime,
                                                    sizes: Int,
                                                    quanta: UInt32,

--- a/Sources/DLABCapture/CaptureVideoPreview.swift
+++ b/Sources/DLABCapture/CaptureVideoPreview.swift
@@ -145,12 +145,6 @@ public class CaptureVideoPreview: NSView, CALayerDelegate {
         set { cache.displayLink = newValue }
     }
     
-    /// Suspend DisplayLink on idle (experimental)
-    private var suspendDisplayLinkOnIdle: Bool = false
-    
-    /// Idle monitor limitation in seconds (experimental)
-    private var FREEWHEELING_PERIOD_IN_SECONDS :Float64 = 1.0
-    
     /// VideoSampleBuffer to enqueue on Output Handler
     private var newSampleBuffer :CMSampleBuffer? = nil
     
@@ -782,29 +776,6 @@ public class CaptureVideoPreview: NSView, CALayerDelegate {
                 let targetTimestampStr = String(format: "%012.3f", targetTimestamp)
                 printDebug("CaptureVideoPreview.\(#function)",
                            "NOTICE:\(targetTimestampStr): No sampleBuffer to enqueue. ")
-            }
-        }
-        
-        // experimental: suspend DisplayLink if idle
-        if suspendDisplayLinkOnIdle {
-            // Suspend DisplayLink if idle
-            let idleTime = CVGetCurrentHostTime() - lastQueuedHostTime
-            let idleTimeInSec = timeIntervalFromHostTime(idleTime)
-            if idleTimeInSec > FREEWHEELING_PERIOD_IN_SECONDS {
-                let targetTimestampStr = String(format: "%012.3f", targetTimestamp)
-                let idleTimeInSecStr = String(format: "%08.3f", idleTimeInSec)
-                printVerbose("CaptureVideoPreview.\(#function)",
-                             "NOTICE:\(targetTimestampStr):\(idleTimeInSecStr): No enqueue - Consider to suspend DisplayLink.")
-                
-                _ = suspendDisplayLink()
-            }
-            else {
-                if debugLog {
-                    let targetTimestampStr = String(format: "%012.3f", targetTimestamp)
-                    let idleTimeInSecStr = String(format: "%08.3f", idleTimeInSec)
-                    printDebug("CaptureVideoPreview.\(#function)",
-                               "NOTICE:\(targetTimestampStr):\(idleTimeInSecStr): No enqueue.")
-                }
             }
         }
         return false

--- a/Sources/DLABCapture/CaptureVideoPreview.swift
+++ b/Sources/DLABCapture/CaptureVideoPreview.swift
@@ -255,34 +255,32 @@ public class CaptureVideoPreview: NSView, CALayerDelegate {
             printVerbose("NOTICE: CaptureVideoPreview is already prepared. (\(#function))")
             return
         }
-        do {
-            guard let baseLayer = layer else {
-                printVerbose("CaptureVideoPreview.\(#function)",
-                             "ERROR: baseLayer is not available.")
-                return
-            }
-            guard let videoLayer = videoLayer else {
-                printVerbose("CaptureVideoPreview.\(#function)",
-                             "ERROR: videoLayer is not available.")
-                return
-            }
-            
-            // Initialize Timebase
-            resetTimebase(nil)
-            flushImage()
-            
-            // Add CMSampleBufferDisplayLayer to SubLayer
-            if videoLayer.superlayer == nil {
-                baseLayer.addSublayer(videoLayer)
-            }
-            
-            if useDisplayLink {
-                prepareDisplayLink()
-            }
-            
-            prepared = true
-            donotEnqueue = !prepared
+        guard let baseLayer = layer else {
+            printVerbose("CaptureVideoPreview.\(#function)",
+                         "ERROR: baseLayer is not available.")
+            return
         }
+        guard let videoLayer = videoLayer else {
+            printVerbose("CaptureVideoPreview.\(#function)",
+                         "ERROR: videoLayer is not available.")
+            return
+        }
+        
+        // Initialize Timebase
+        resetTimebase(nil)
+        flushImage()
+        
+        // Add CMSampleBufferDisplayLayer to SubLayer
+        if videoLayer.superlayer == nil {
+            baseLayer.addSublayer(videoLayer)
+        }
+        
+        if useDisplayLink {
+            prepareDisplayLink()
+        }
+        
+        prepared = true
+        donotEnqueue = !prepared
     }
     
     /// Shutdown videoPreview and CVDisplayLink.
@@ -292,38 +290,36 @@ public class CaptureVideoPreview: NSView, CALayerDelegate {
             printVerbose("NOTICE: CaptureVideoPreview is not prepared. (\(#function))")
             return
         }
-        do {
-            prepared = false
-            donotEnqueue = !prepared
-            
-            if useDisplayLink {
-                shutdownDisplayLink()
-            }
-            
-            // Remove CMSampleBufferDisplayLayer from SubLayer
-            if let videoLayer = videoLayer {
-                if videoLayer.superlayer != nil {
-                    videoLayer.removeFromSuperlayer()
-                }
-                videoLayer.flushAndRemoveImage()
-            } else {
-                printVerbose("CaptureVideoPreview.\(#function)",
-                             "ERROR: videoLayer is not available.")
-            }
-            
-            // Initialize Timebase
-            resetTimebase(nil)
-            
-            //
-            lastQueuedHostTime = 0
-            
-            //
-            sbHelper.resetSampleRect()
-            sampleAspectRatio = nil
-            sampleEncodedSize = nil
-            sampleCleanSize = nil
-            sampleProductionSize = nil
+        prepared = false
+        donotEnqueue = !prepared
+        
+        if useDisplayLink {
+            shutdownDisplayLink()
         }
+        
+        // Remove CMSampleBufferDisplayLayer from SubLayer
+        if let videoLayer = videoLayer {
+            if videoLayer.superlayer != nil {
+                videoLayer.removeFromSuperlayer()
+            }
+            videoLayer.flushAndRemoveImage()
+        } else {
+            printVerbose("CaptureVideoPreview.\(#function)",
+                         "ERROR: videoLayer is not available.")
+        }
+        
+        // Initialize Timebase
+        resetTimebase(nil)
+        
+        //
+        lastQueuedHostTime = 0
+        
+        //
+        sbHelper.resetSampleRect()
+        sampleAspectRatio = nil
+        sampleEncodedSize = nil
+        sampleCleanSize = nil
+        sampleProductionSize = nil
     }
     
     /// Non-blocking enqueue of CMSampleBuffer.
@@ -400,33 +396,31 @@ public class CaptureVideoPreview: NSView, CALayerDelegate {
             newSampleBuffer = sampleBuffer
         } else {
             // Instant queueing
-            do {
-                guard let vLayer = videoLayer else {
-                    printVerbose("CaptureVideoPreview.\(#function)",
-                                 "ERROR: videoLayer is nil")
-                    return
-                }
+            guard let vLayer = videoLayer else {
+                printVerbose("CaptureVideoPreview.\(#function)",
+                             "ERROR: videoLayer is nil")
+                return
+            }
+            
+            let statusOK :Bool = (vLayer.status != .failed)
+            let ready :Bool = vLayer.isReadyForMoreMediaData
+            if statusOK && ready {
                 
-                let statusOK :Bool = (vLayer.status != .failed)
-                let ready :Bool = vLayer.isReadyForMoreMediaData
-                if statusOK && ready {
-                    
-                    // Enqueue samplebuffer
-                    vLayer.enqueue(sampleBuffer)
-                    lastQueuedHostTime = CVGetCurrentHostTime()
-                    
-                    // Release enqueued CMSampleBuffer
-                    newSampleBuffer = nil
-                    
-                } else {
-                    var eStr = ""
-                    if !statusOK { eStr += "StatusFailed " }
-                    if !ready { eStr += "NotReady " }
-                    printVerbose("CaptureVideoPreview.\(#function)",
-                                 "ERROR:(Instant queueing): videoLayer is not ready to enqueue. \(eStr)")
-                    
-                    flushImage()
-                }
+                // Enqueue samplebuffer
+                vLayer.enqueue(sampleBuffer)
+                lastQueuedHostTime = CVGetCurrentHostTime()
+                
+                // Release enqueued CMSampleBuffer
+                newSampleBuffer = nil
+                
+            } else {
+                var eStr = ""
+                if !statusOK { eStr += "StatusFailed " }
+                if !ready { eStr += "NotReady " }
+                printVerbose("CaptureVideoPreview.\(#function)",
+                             "ERROR:(Instant queueing): videoLayer is not ready to enqueue. \(eStr)")
+                
+                flushImage()
             }
         }
     }
@@ -572,29 +566,27 @@ public class CaptureVideoPreview: NSView, CALayerDelegate {
     /// - Parameter sampleBuffer: timebase source sampleBuffer. Set nil to reset to shutdown.
     private func resetTimebase(_ sampleBuffer :CMSampleBuffer?) {
         printVerbose("CaptureVideoPreview.\(#function)")
-        do {
-            if let sampleBuffer = sampleBuffer {
-                // start Media Time from sampleBuffer's presentation time
-                let time = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
-                if let vLayer = videoLayer, let timebase = vLayer.controlTimebase {
-                    _ = CMTimebaseSetTime(timebase, time: time)
-                    _ = CMTimebaseSetRate(timebase, rate: 1.0)
-                }
-                
-                // Record base HostTime value as video timebase
-                baseHostTime = CVGetCurrentHostTime()
-                baseOffsetInSec = CMTimeGetSeconds(time)
-            } else {
-                // reset Media Time to Zero
-                if let vLayer = videoLayer, let timebase = vLayer.controlTimebase {
-                    _ = CMTimebaseSetRate(timebase, rate: 0.0)
-                    _ = CMTimebaseSetTime(timebase, time: CMTime.zero)
-                }
-                
-                // Clear base HostTime value
-                baseHostTime = 0
-                baseOffsetInSec = 0.0
+        if let sampleBuffer = sampleBuffer {
+            // start Media Time from sampleBuffer's presentation time
+            let time = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+            if let vLayer = videoLayer, let timebase = vLayer.controlTimebase {
+                _ = CMTimebaseSetTime(timebase, time: time)
+                _ = CMTimebaseSetRate(timebase, rate: 1.0)
             }
+            
+            // Record base HostTime value as video timebase
+            baseHostTime = CVGetCurrentHostTime()
+            baseOffsetInSec = CMTimeGetSeconds(time)
+        } else {
+            // reset Media Time to Zero
+            if let vLayer = videoLayer, let timebase = vLayer.controlTimebase {
+                _ = CMTimebaseSetRate(timebase, rate: 0.0)
+                _ = CMTimebaseSetTime(timebase, time: CMTime.zero)
+            }
+            
+            // Clear base HostTime value
+            baseHostTime = 0
+            baseOffsetInSec = 0.0
         }
         if debugLog {
             let baseHostTimeInSecStr = String(format:"%012.3f", timeIntervalFromHostTime(baseHostTime))
@@ -825,25 +817,23 @@ public class CaptureVideoPreview: NSView, CALayerDelegate {
         donotEnqueue = true
         newSampleBuffer = nil
         
-        do {
-            if preferCADisplayLink, #available(macOS 14.0, *) {
-                // Remove CADisplayLink
-                if let caDisplayLink = caDisplayLink as? CADisplayLink {
-                    caDisplayLink.invalidate()
-                }
-                self.caDisplayLink = nil
-            } else {
-                // Unregister observer
-                NotificationCenter.default.removeObserver(self)
-                
-                // Remove CVDisplayLink
-                if let displayLink = displayLink {
-                    if CVDisplayLinkIsRunning(displayLink) {
-                        _ = CVDisplayLinkStop(displayLink)
-                    }
-                }
-                self.displayLink = nil
+        if preferCADisplayLink, #available(macOS 14.0, *) {
+            // Remove CADisplayLink
+            if let caDisplayLink = caDisplayLink as? CADisplayLink {
+                caDisplayLink.invalidate()
             }
+            self.caDisplayLink = nil
+        } else {
+            // Unregister observer
+            NotificationCenter.default.removeObserver(self)
+            
+            // Remove CVDisplayLink
+            if let displayLink = displayLink {
+                if CVDisplayLinkIsRunning(displayLink) {
+                    _ = CVDisplayLinkStop(displayLink)
+                }
+            }
+            self.displayLink = nil
         }
     }
     
@@ -853,27 +843,25 @@ public class CaptureVideoPreview: NSView, CALayerDelegate {
     /// @discussion Under macOS 14.0 and later, CADisplayLink is used instead of CVDisplayLink.
     private func activateDisplayLink() -> Bool {
         var result = false;
-        do {
-            if preferCADisplayLink, #available(macOS 14.0, *) {
-                if let caDisplayLink = caDisplayLink as? CADisplayLink {
-                    if caDisplayLink.isPaused {
-                        caDisplayLink.isPaused = false
-                    }
-                    result = !caDisplayLink.isPaused
-                } else {
-                    printVerbose("CaptureVideoPreview.\(#function)",
-                                 "ERROR: CADisplayLink is not valid.")
+        if preferCADisplayLink, #available(macOS 14.0, *) {
+            if let caDisplayLink = caDisplayLink as? CADisplayLink {
+                if caDisplayLink.isPaused {
+                    caDisplayLink.isPaused = false
                 }
+                result = !caDisplayLink.isPaused
             } else {
-                if let displayLink = displayLink {
-                    if !CVDisplayLinkIsRunning(displayLink) {
-                        _ = CVDisplayLinkStart(displayLink)
-                    }
-                    result = CVDisplayLinkIsRunning(displayLink)
-                } else {
-                    printVerbose("CaptureVideoPreview.\(#function)",
-                                 "ERROR: CVDisplayLink is not valid.")
+                printVerbose("CaptureVideoPreview.\(#function)",
+                             "ERROR: CADisplayLink is not valid.")
+            }
+        } else {
+            if let displayLink = displayLink {
+                if !CVDisplayLinkIsRunning(displayLink) {
+                    _ = CVDisplayLinkStart(displayLink)
                 }
+                result = CVDisplayLinkIsRunning(displayLink)
+            } else {
+                printVerbose("CaptureVideoPreview.\(#function)",
+                             "ERROR: CVDisplayLink is not valid.")
             }
         }
         
@@ -888,27 +876,25 @@ public class CaptureVideoPreview: NSView, CALayerDelegate {
     /// @discussion Under macOS 14.0 and later, CADisplayLink is used instead of CVDisplayLink.
     private func suspendDisplayLink() -> Bool {
         var result = false;
-        do {
-            if preferCADisplayLink, #available(macOS 14.0, *) {
-                if let caDisplayLink = caDisplayLink as? CADisplayLink {
-                    if !caDisplayLink.isPaused {
-                        caDisplayLink.isPaused = true
-                    }
-                    result = caDisplayLink.isPaused
-                } else {
-                    printVerbose("CaptureVideoPreview.\(#function)",
-                                 "ERROR: CADisplayLink is not valid.")
+        if preferCADisplayLink, #available(macOS 14.0, *) {
+            if let caDisplayLink = caDisplayLink as? CADisplayLink {
+                if !caDisplayLink.isPaused {
+                    caDisplayLink.isPaused = true
                 }
-            } else  {
-                if let displayLink = displayLink {
-                    if CVDisplayLinkIsRunning(displayLink) {
-                        _ = CVDisplayLinkStop(displayLink)
-                    }
-                    result = !CVDisplayLinkIsRunning(displayLink)
-                } else {
-                    printVerbose("CaptureVideoPreview.\(#function)",
-                                 "ERROR: CVDisplayLink is not valid.")
+                result = caDisplayLink.isPaused
+            } else {
+                printVerbose("CaptureVideoPreview.\(#function)",
+                             "ERROR: CADisplayLink is not valid.")
+            }
+        } else  {
+            if let displayLink = displayLink {
+                if CVDisplayLinkIsRunning(displayLink) {
+                    _ = CVDisplayLinkStop(displayLink)
                 }
+                result = !CVDisplayLinkIsRunning(displayLink)
+            } else {
+                printVerbose("CaptureVideoPreview.\(#function)",
+                             "ERROR: CVDisplayLink is not valid.")
             }
         }
         if result {
@@ -921,26 +907,24 @@ public class CaptureVideoPreview: NSView, CALayerDelegate {
     /// Update linked CGDirectDisplayID with current view's displayID.
     @objc private func updateDisplayLink() {
         printVerbose("CaptureVideoPreview.\(#function)")
-        do {
-            if let displayLink = displayLink {
-                let linkedDisplayID = CVDisplayLinkGetCurrentCGDisplay(displayLink)
-                
-                var viewDisplayID :CGDirectDisplayID = CGMainDisplayID()
-                if let window = window, let screen = window.screen {
-                    let screenNumberKey = NSDeviceDescriptionKey("NSScreenNumber")
-                    if let viewScreenNumber = screen.deviceDescription[screenNumberKey] as? NSNumber {
-                        viewDisplayID = viewScreenNumber.uint32Value
-                    }
+        if let displayLink = displayLink {
+            let linkedDisplayID = CVDisplayLinkGetCurrentCGDisplay(displayLink)
+            
+            var viewDisplayID :CGDirectDisplayID = CGMainDisplayID()
+            if let window = window, let screen = window.screen {
+                let screenNumberKey = NSDeviceDescriptionKey("NSScreenNumber")
+                if let viewScreenNumber = screen.deviceDescription[screenNumberKey] as? NSNumber {
+                    viewDisplayID = viewScreenNumber.uint32Value
                 }
-                
-                if linkedDisplayID != viewDisplayID {
-                    if CVDisplayLinkIsRunning(displayLink) {
-                        _ = CVDisplayLinkStop(displayLink)
-                        _ = CVDisplayLinkSetCurrentCGDisplay(displayLink, viewDisplayID)
-                        _ = CVDisplayLinkStart(displayLink)
-                    } else {
-                        _ = CVDisplayLinkSetCurrentCGDisplay(displayLink, viewDisplayID)
-                    }
+            }
+            
+            if linkedDisplayID != viewDisplayID {
+                if CVDisplayLinkIsRunning(displayLink) {
+                    _ = CVDisplayLinkStop(displayLink)
+                    _ = CVDisplayLinkSetCurrentCGDisplay(displayLink, viewDisplayID)
+                    _ = CVDisplayLinkStart(displayLink)
+                } else {
+                    _ = CVDisplayLinkSetCurrentCGDisplay(displayLink, viewDisplayID)
                 }
             }
         }

--- a/Sources/DLABCapture/CaptureWriter.swift
+++ b/Sources/DLABCapture/CaptureWriter.swift
@@ -990,18 +990,6 @@ actor CaptureWriter: NSObject {
             }
         }
         
-        #if false
-        // For H264 encoder (using Main 3.1 maximum bitrate)
-        compressionProperties[AVVideoAverageBitRateKey] = 14*1000*1000
-        compressionProperties[AVVideoMaxKeyFrameIntervalKey] = 29
-        compressionProperties[AVVideoMaxKeyFrameIntervalDurationKey] = 1.0
-        compressionProperties[AVVideoAllowFrameReorderingKey] = true
-        compressionProperties[AVVideoProfileLevelKey] = AVVideoProfileLevelH264Main31
-        compressionProperties[AVVideoH264EntropyModeKey] = AVVideoH264EntropyModeCABAC
-        compressionProperties[AVVideoExpectedSourceFrameRateKey] = 30
-        compressionProperties[AVVideoAverageNonDroppableFrameRateKey] = 10
-        #endif
-        
         if let fieldDetail = fieldDetail {
             // Use interlaced encoding
             let keyFieldCount = kVTCompressionPropertyKey_FieldCount as String

--- a/Sources/DLABCapture/CaptureWriter.swift
+++ b/Sources/DLABCapture/CaptureWriter.swift
@@ -491,11 +491,9 @@ actor CaptureWriter: NSObject {
     
     private func prepareDefaultURL() -> URL? {
         var movieFolders : [String]? = nil
-        do {
-            let moviesPathDirectory = FileManager.SearchPathDirectory.moviesDirectory
-            let userDomainMask = FileManager.SearchPathDomainMask.userDomainMask
-            movieFolders = NSSearchPathForDirectoriesInDomains(moviesPathDirectory, userDomainMask, true)
-        }
+        let moviesPathDirectory = FileManager.SearchPathDirectory.moviesDirectory
+        let userDomainMask = FileManager.SearchPathDomainMask.userDomainMask
+        movieFolders = NSSearchPathForDirectoriesInDomains(moviesPathDirectory, userDomainMask, true)
         
         if let movieFolder = movieFolders?.first {
             let formatter = DateFormatter()
@@ -655,49 +653,43 @@ actor CaptureWriter: NSObject {
     /* ============================================ */
     
     private func initializeTimeStamp() {
-        do {
-            // reset TS variables and duration
-            isInitialTSReady = false
-            startTime = CMTime.zero
-            endTime = CMTime.zero
-            duration = 0.0
-        }
+        // reset TS variables and duration
+        isInitialTSReady = false
+        startTime = CMTime.zero
+        endTime = CMTime.zero
+        duration = 0.0
     }
     
     private func updateTimeStamp(_ sampleBuffer: CMSampleBuffer) {
-        do {
-            // Update InitialTimeStamp and EndTimeStamp
-            let sbPresentation = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
-            let sbDuration = CMSampleBufferGetDuration(sampleBuffer)
+        // Update InitialTimeStamp and EndTimeStamp
+        let sbPresentation = CMSampleBufferGetPresentationTimeStamp(sampleBuffer)
+        let sbDuration = CMSampleBufferGetDuration(sampleBuffer)
+        
+        // Set startTime CMTime value
+        if let avAssetWriter = avAssetWriter, isInitialTSReady == false {
+            // Set initial SourceTime value for AVAssetWriter
+            avAssetWriter.startSession(atSourceTime: sbPresentation)
             
-            // Set startTime CMTime value
-            if let avAssetWriter = avAssetWriter, isInitialTSReady == false {
-                // Set initial SourceTime value for AVAssetWriter
-                avAssetWriter.startSession(atSourceTime: sbPresentation)
-                
-                // Set initial time stamp for session
-                isInitialTSReady = true
-                startTime = sbPresentation
-            }
-            
-            // Update endTime/duration CMTime value
-            endTime = CMTimeAdd(sbPresentation, sbDuration)
-            duration = CMTimeGetSeconds(CMTimeSubtract(endTime, startTime))
+            // Set initial time stamp for session
+            isInitialTSReady = true
+            startTime = sbPresentation
         }
+        
+        // Update endTime/duration CMTime value
+        endTime = CMTimeAdd(sbPresentation, sbDuration)
+        duration = CMTimeGetSeconds(CMTimeSubtract(endTime, startTime))
     }
     
     private func finalizeTimeStamp() {
-        do {
-            // Calc duration and Reset CMTime values
-            if isInitialTSReady == true {
-                duration = CMTimeGetSeconds(CMTimeSubtract(endTime, startTime))
-            } else {
-                duration = 0.0
-            }
-            isInitialTSReady = false
-            startTime = CMTime.zero
-            endTime = CMTime.zero
+        // Calc duration and Reset CMTime values
+        if isInitialTSReady == true {
+            duration = CMTimeGetSeconds(CMTimeSubtract(endTime, startTime))
+        } else {
+            duration = 0.0
         }
+        isInitialTSReady = false
+        startTime = CMTime.zero
+        endTime = CMTime.zero
     }
     
     /* ============================================ */
@@ -872,15 +864,13 @@ actor CaptureWriter: NSObject {
             }
         }
         if useTimecode {
-            do {
-                // Create AVAssetWriterInput for Timecode (SMPTE)
-                avAssetWriterInputTimecode = AVAssetWriterInput(mediaType: AVMediaType.timecode,
-                                                                outputSettings: nil)
-                
-                if let inputVideo = avAssetWriterInputVideo, let inputTimeCode = avAssetWriterInputTimecode {
-                    inputVideo.addTrackAssociation(withTrackOf: inputTimeCode,
-                                                   type: AVAssetTrack.AssociationType.timecode.rawValue)
-                }
+            // Create AVAssetWriterInput for Timecode (SMPTE)
+            avAssetWriterInputTimecode = AVAssetWriterInput(mediaType: AVMediaType.timecode,
+                                                            outputSettings: nil)
+            
+            if let inputVideo = avAssetWriterInputVideo, let inputTimeCode = avAssetWriterInputTimecode {
+                inputVideo.addTrackAssociation(withTrackOf: inputTimeCode,
+                                               type: AVAssetTrack.AssociationType.timecode.rawValue)
             }
             
             // Apply preferred timecode media timescale
@@ -974,20 +964,18 @@ actor CaptureWriter: NSObject {
         } else {
             codecString = AVVideoCodecType.h264.rawValue
         }
-        do {
-            if codecString == "avc1" {
-                compressionProperties[AVVideoProfileLevelKey] = AVVideoProfileLevelH264HighAutoLevel
-                compressionProperties[AVVideoH264EntropyModeKey] = AVVideoH264EntropyModeCABAC
-                compressionProperties[AVVideoAllowFrameReorderingKey] = true
-                compressionProperties[AVVideoMaxKeyFrameIntervalDurationKey] = 1.0
-                compressionProperties[AVVideoExpectedSourceFrameRateKey] = encodeVideoFrameRate
-            }
-            if codecString == "hvc1" {
-                compressionProperties[AVVideoProfileLevelKey] = kVTProfileLevel_HEVC_Main_AutoLevel as String
-                compressionProperties[AVVideoAllowFrameReorderingKey] = true
-                compressionProperties[AVVideoMaxKeyFrameIntervalDurationKey] = 1.0
-                compressionProperties[AVVideoExpectedSourceFrameRateKey] = encodeVideoFrameRate
-            }
+        if codecString == "avc1" {
+            compressionProperties[AVVideoProfileLevelKey] = AVVideoProfileLevelH264HighAutoLevel
+            compressionProperties[AVVideoH264EntropyModeKey] = AVVideoH264EntropyModeCABAC
+            compressionProperties[AVVideoAllowFrameReorderingKey] = true
+            compressionProperties[AVVideoMaxKeyFrameIntervalDurationKey] = 1.0
+            compressionProperties[AVVideoExpectedSourceFrameRateKey] = encodeVideoFrameRate
+        }
+        if codecString == "hvc1" {
+            compressionProperties[AVVideoProfileLevelKey] = kVTProfileLevel_HEVC_Main_AutoLevel as String
+            compressionProperties[AVVideoAllowFrameReorderingKey] = true
+            compressionProperties[AVVideoMaxKeyFrameIntervalDurationKey] = 1.0
+            compressionProperties[AVVideoExpectedSourceFrameRateKey] = encodeVideoFrameRate
         }
         
         if let fieldDetail = fieldDetail {
@@ -1024,21 +1012,19 @@ actor CaptureWriter: NSObject {
         if let sourceAudioFormatDescription = sourceAudioFormatDescription {
             var avaf : AVAudioFormat? = nil
             var aclData : NSData? = nil
-            do {
-                let asbd_p : UnsafePointer<AudioStreamBasicDescription>? =
-                    CMAudioFormatDescriptionGetStreamBasicDescription(sourceAudioFormatDescription)
-                if let asbd_p = asbd_p {
-                    var layoutSize : Int = 0
-                    let acl_p : UnsafePointer<AudioChannelLayout>? =
-                        CMAudioFormatDescriptionGetChannelLayout(sourceAudioFormatDescription, sizeOut: &layoutSize)
-                    if let acl_p = acl_p {
-                        let avacl = AVAudioChannelLayout.init(layout: acl_p)
-                        avaf = AVAudioFormat.init(streamDescription: asbd_p, channelLayout: avacl)
-                        aclData = NSData.init(bytes: UnsafeRawPointer(acl_p), length: layoutSize)
-                    } else {
-                        avaf = AVAudioFormat.init(streamDescription: asbd_p)
-                        aclData = nil
-                    }
+            let asbd_p : UnsafePointer<AudioStreamBasicDescription>? =
+                CMAudioFormatDescriptionGetStreamBasicDescription(sourceAudioFormatDescription)
+            if let asbd_p = asbd_p {
+                var layoutSize : Int = 0
+                let acl_p : UnsafePointer<AudioChannelLayout>? =
+                    CMAudioFormatDescriptionGetChannelLayout(sourceAudioFormatDescription, sizeOut: &layoutSize)
+                if let acl_p = acl_p {
+                    let avacl = AVAudioChannelLayout.init(layout: acl_p)
+                    avaf = AVAudioFormat.init(streamDescription: asbd_p, channelLayout: avacl)
+                    aclData = NSData.init(bytes: UnsafeRawPointer(acl_p), length: layoutSize)
+                } else {
+                    avaf = AVAudioFormat.init(streamDescription: asbd_p)
+                    aclData = nil
                 }
             }
             

--- a/Sources/DLABCapture/CaptureWriter.swift
+++ b/Sources/DLABCapture/CaptureWriter.swift
@@ -164,7 +164,7 @@ private final class DispatchWorkItemBox: @unchecked Sendable {
 /// Callers should await `closeSession()` before releasing the writer.
 /// Cleanup performed from `deinit` is a fallback path only, and it waits for
 /// `finishWriting` for a bounded amount of time before giving up.
-actor CaptureWriter: NSObject {
+actor CaptureWriter {
     typealias AssetWriterFactory = @Sendable (URL, AVFileType) throws -> AVAssetWriter
     public typealias DiagnosticHandler = @Sendable (CaptureWriterDiagnostic) -> Void
     public static let defaultFinishWritingTimeoutSeconds: TimeInterval = 5.0
@@ -329,8 +329,7 @@ actor CaptureWriter: NSObject {
     // MARK: - public init/deinit
     /* ============================================ */
     
-    override init() {
-        super.init()
+    init() {
         cache.finishWritingTimeoutSeconds = finishWritingTimeoutSecondsStorage
         
         // print("Writer.init")

--- a/Sources/DLABCapture/VideoSampleBufferHelper.swift
+++ b/Sources/DLABCapture/VideoSampleBufferHelper.swift
@@ -55,7 +55,8 @@ internal final class VideoSampleBufferHelper: @unchecked Sendable {
             CVPixelBufferPoolFlush(pool, .excessBuffers)
             pixelBufferPoolStorage = nil
         }
-        let poolAttr = [kCVPixelBufferPoolMinimumBufferCountKey: 4 as CFNumber] as CFDictionary
+        let poolAttr = [kCVPixelBufferPoolMinimumBufferCountKey: 4 as CFNumber,
+                         kCVPixelBufferPoolMaximumBufferAgeKey: 0.5 as CFNumber] as CFDictionary
         let err = CVPixelBufferPoolCreate(kCFAllocatorDefault, poolAttr, dict, &pixelBufferPoolStorage)
         guard let pool = pixelBufferPoolStorage else {
             print("ERROR: VideoSampleBufferHelper - Failed to create CVPixelBufferPool (err=\(err))")

--- a/Sources/DLABCapture/VideoSampleBufferHelper.swift
+++ b/Sources/DLABCapture/VideoSampleBufferHelper.swift
@@ -56,7 +56,7 @@ internal final class VideoSampleBufferHelper: @unchecked Sendable {
             pixelBufferPoolStorage = nil
         }
         let poolAttr = [kCVPixelBufferPoolMinimumBufferCountKey: 4 as CFNumber,
-                         kCVPixelBufferPoolMaximumBufferAgeKey: 0.5 as CFNumber] as CFDictionary
+                          kCVPixelBufferPoolMaximumBufferAgeKey: 0.5 as CFNumber] as CFDictionary
         let err = CVPixelBufferPoolCreate(kCFAllocatorDefault, poolAttr, dict, &pixelBufferPoolStorage)
         guard let pool = pixelBufferPoolStorage else {
             print("ERROR: VideoSampleBufferHelper - Failed to create CVPixelBufferPool (err=\(err))")

--- a/Sources/DLABCapture/VideoStyle.swift
+++ b/Sources/DLABCapture/VideoStyle.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2017-2026 MyCometG3. All rights reserved.
 //
 
-import Foundation
 import AVFoundation
 
 public enum VideoStyle : String, Sendable {

--- a/Sources/DLABridging/include/DLABDevice.h
+++ b/Sources/DLABridging/include/DLABDevice.h
@@ -261,7 +261,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param buffer VANC buffer of specified lineNumber.
  @return Return FALSE if further call is not required.
  */
-typedef BOOL (^VANCHandler) (CMSampleTimingInfo timingInfo, uint32_t lineNumber, void* buffer) DEPRECATED_MSG_ATTRIBUTE("Deprecated since SDK 16.0.");
+typedef BOOL (^VANCHandler) (CMSampleTimingInfo timingInfo, uint32_t lineNumber, void* _Nonnull buffer) DEPRECATED_MSG_ATTRIBUTE("Deprecated since SDK 16.0.");
 
 /**
  VANC Packet support : VANC Capture callback block
@@ -327,10 +327,10 @@ typedef BOOL (^InputAncillaryPacketHandler) (CMSampleTimingInfo timingInfo,
  @return data VANC Packet data encoded in bmdAncillaryPacketFormatUInt8 format. Return nil if further calls are not required.
  */
 typedef NSData* _Nullable (^OutputVANCPacketHandler) (CMSampleTimingInfo timingInfo,
-                                                      uint8_t* did,
-                                                      uint8_t* sdid,
-                                                      uint32_t* lineNumber,
-                                                      uint8_t* dataStreamIndex);
+                                                      uint8_t* _Nonnull did,
+                                                      uint8_t* _Nonnull sdid,
+                                                      uint32_t* _Nonnull lineNumber,
+                                                      uint8_t* _Nonnull dataStreamIndex);
 
 /**
  Ancillary packet support : playback callback block (SDK 15.3 or later)
@@ -349,11 +349,11 @@ typedef NSData* _Nullable (^OutputVANCPacketHandler) (CMSampleTimingInfo timingI
  @return data Ancillary packet data encoded in bmdAncillaryPacketFormatUInt8 format. Return nil if further calls are not required.
  */
 typedef NSData* _Nullable (^OutputAncillaryPacketHandler) (CMSampleTimingInfo timingInfo,
-                                                           uint8_t* did,
-                                                           uint8_t* sdid,
-                                                           uint32_t* lineNumber,
-                                                           uint8_t* dataStreamIndex,
-                                                           DLABAncillaryDataSpace* dataSpace);
+                                                           uint8_t* _Nonnull did,
+                                                           uint8_t* _Nonnull sdid,
+                                                           uint32_t* _Nonnull lineNumber,
+                                                           uint8_t* _Nonnull dataStreamIndex,
+                                                           DLABAncillaryDataSpace* _Nonnull dataSpace);
 NS_ASSUME_NONNULL_END
 
 /* =================================================================================== */


### PR DESCRIPTION
This PR integrates the reviewed fix stack from the current session into `work`.

Reviewed changes included:
- L1 typo fix in `CaptureManager+Util.swift`
- L2 dead code removal in `CaptureWriter.swift`
- L4 scope-only `do { }` cleanup
- L8 redundant import removal in `VideoStyle.swift`
- L3 dead path removal in `CaptureVideoPreview.swift`
- L6 `_Nonnull` annotations for block typedef raw pointer parameters in `DLABDevice.h`
- L9 removal of unnecessary `NSObject` inheritance from `CaptureWriter`
- L10 `kCVPixelBufferPoolMaximumBufferAgeKey` addition in `VideoSampleBufferHelper.swift`

Validation:
- `swift build`
- `swift test`

The branch was re-reviewed before merge, and no blocking issues were found.
