### PR TITLE
Refactor COM downcasts with DLABQueryInterfaceAny

### DIFF
--- a/Sources/DLABridging/src/DLABDevice+Input.mm
+++ b/Sources/DLABridging/src/DLABDevice+Input.mm
@@ -1044,15 +1044,15 @@ static DLABTimecodeSetting* createTimecodeSetting(IDeckLinkVideoInputFrame* vide
         }];
         if (queryFailureReason) {
             [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-                                                     reason:queryFailureReason
-                                                       code:queryResult
-                                                         to:error];
+                reason:queryFailureReason
+                  code:queryResult
+                    to:error];
             return nil;
         }
         if (result) {
             [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-                                                     reason:@"IDeckLinkInput::DoesSupportVideoMode failed."
-                                                       code:result
+                reason:@"IDeckLinkInput::DoesSupportVideoMode failed."
+                  code:result
                     to:error];
             return nil;
         }

--- a/Sources/DLABridging/src/DLABDevice+Input.mm
+++ b/Sources/DLABridging/src/DLABDevice+Input.mm
@@ -268,8 +268,12 @@ NS_INLINE BOOL copyBufferDLtoCV(DLABDevice* self, IDeckLinkVideoFrame* videoFram
         if (!pre1403) {
             VideoBufferGetBaseAddress(videoBuffer, &src);
         } else {
-            IDeckLinkVideoFrame_v14_2_1* videoFrame_v14_2_1 = (IDeckLinkVideoFrame_v14_2_1*)videoFrame;
-            videoFrame_v14_2_1->GetBytes(&src);
+            IDeckLinkVideoFrame_v14_2_1* videoFrame_v14_2_1 = NULL;
+            HRESULT queryResult = DLABQueryInterfaceAny(videoFrame, &videoFrame_v14_2_1, IID_IDeckLinkVideoFrame_v14_2_1);
+            if (queryResult == S_OK && videoFrame_v14_2_1) {
+                videoFrame_v14_2_1->GetBytes(&src);
+            }
+            DLABReleaseIfNeeded(videoFrame_v14_2_1);
         }
         
         vImage_Buffer sourceBuffer = {0};
@@ -341,8 +345,12 @@ NS_INLINE BOOL copyPlaneDLtoCV(DLABDevice* self, IDeckLinkVideoInputFrame* video
         if (!pre1403) {
             VideoBufferGetBaseAddress(videoBuffer, &src);
         } else {
-            IDeckLinkVideoFrame_v14_2_1* videoFrame_v14_2_1 = (IDeckLinkVideoFrame_v14_2_1*)videoFrame;
-            videoFrame_v14_2_1->GetBytes(&src);
+            IDeckLinkVideoFrame_v14_2_1* videoFrame_v14_2_1 = NULL;
+            HRESULT queryResult = DLABQueryInterfaceAny(videoFrame, &videoFrame_v14_2_1, IID_IDeckLinkVideoFrame_v14_2_1);
+            if (queryResult == S_OK && videoFrame_v14_2_1) {
+                videoFrame_v14_2_1->GetBytes(&src);
+            }
+            DLABReleaseIfNeeded(videoFrame_v14_2_1);
         }
         
         if (dst && src) {
@@ -987,28 +995,42 @@ static DLABTimecodeSetting* createTimecodeSetting(IDeckLinkVideoInputFrame* vide
     IDeckLinkInput *input = self.deckLinkInput;
     if (input) {
         __block HRESULT result = E_FAIL;
+        __block HRESULT queryResult = S_OK;
+        __block NSString *queryFailureReason = nil;
         __block BMDDisplayMode actualMode = 0;
         __block bool supported = false;
         __block bool pre1403 = [DLABVersionChecker checkPre1403];
         __block bool pre1105 = [DLABVersionChecker checkPre1105];
         [self capture_sync:^{
             if (pre1105) {
-                IDeckLinkInput_v11_4 *input1104 = (IDeckLinkInput_v11_4*)input;
-                result = input1104->DoesSupportVideoMode(videoConnection,           // BMDVideoConnection = DLABVideoConnection
-                                                         displayMode,               // BMDDisplayMode = DLABDisplayMode
-                                                         pixelFormat,               // BMDPixelFormat = DLABPixelFormat
-                                                         supportedVideoModeFlag,    // BMDSupportedVideoModeFlags = DLABSupportedVideoModeFlag
-                                                         &supported);               // bool
+                IDeckLinkInput_v11_4 *input1104 = NULL;
+                queryResult = DLABQueryInterfaceAny(input, &input1104, IID_IDeckLinkInput_v11_4);
+                if (queryResult == S_OK && input1104) {
+                    result = input1104->DoesSupportVideoMode(videoConnection,           // BMDVideoConnection = DLABVideoConnection
+                                                             displayMode,               // BMDDisplayMode = DLABDisplayMode
+                                                             pixelFormat,               // BMDPixelFormat = DLABPixelFormat
+                                                             supportedVideoModeFlag,    // BMDSupportedVideoModeFlags = DLABSupportedVideoModeFlag
+                                                             &supported);               // bool
+                } else {
+                    queryFailureReason = @"DLABQueryInterfaceAny failed for IDeckLinkInput_v11_4.";
+                }
+                DLABReleaseIfNeeded(input1104);
             } else if (pre1403) {
-                IDeckLinkInput_v14_2_1 *input1402 = (IDeckLinkInput_v14_2_1*)input;
-                BMDVideoInputConversionMode convertMode = bmdNoVideoInputConversion;
-                result = input1402->DoesSupportVideoMode(videoConnection,           // BMDVideoConnection = DLABVideoConnection
-                                                         displayMode,               // BMDDisplayMode = DLABDisplayMode
-                                                         pixelFormat,               // BMDPixelFormat = DLABPixelFormat
-                                                         convertMode,               // BMDVideoInputConversionMode = DLABVideoInputConversionMode
-                                                         supportedVideoModeFlag,    // BMDSupportedVideoModeFlags = DLABSupportedVideoModeFlag
-                                                         &actualMode,               // BMDDisplayMode = DLABDisplayMode
-                                                         &supported);               // bool
+                IDeckLinkInput_v14_2_1 *input1402 = NULL;
+                queryResult = DLABQueryInterfaceAny(input, &input1402, IID_IDeckLinkInput_v14_2_1);
+                if (queryResult == S_OK && input1402) {
+                    BMDVideoInputConversionMode convertMode = bmdNoVideoInputConversion;
+                    result = input1402->DoesSupportVideoMode(videoConnection,           // BMDVideoConnection = DLABVideoConnection
+                                                             displayMode,               // BMDDisplayMode = DLABDisplayMode
+                                                             pixelFormat,               // BMDPixelFormat = DLABPixelFormat
+                                                             convertMode,               // BMDVideoInputConversionMode = DLABVideoInputConversionMode
+                                                             supportedVideoModeFlag,    // BMDSupportedVideoModeFlags = DLABSupportedVideoModeFlag
+                                                             &actualMode,               // BMDDisplayMode = DLABDisplayMode
+                                                             &supported);               // bool
+                } else {
+                    queryFailureReason = @"DLABQueryInterfaceAny failed for IDeckLinkInput_v14_2_1.";
+                }
+                DLABReleaseIfNeeded(input1402);
             } else {
                 BMDVideoInputConversionMode convertMode = bmdNoVideoInputConversion;
                 result = input->DoesSupportVideoMode(videoConnection,           // BMDVideoConnection = DLABVideoConnection
@@ -1020,10 +1042,17 @@ static DLABTimecodeSetting* createTimecodeSetting(IDeckLinkVideoInputFrame* vide
                                                      &supported);               // bool
             }
         }];
+        if (queryFailureReason) {
+            [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
+                                                     reason:queryFailureReason
+                                                       code:queryResult
+                                                         to:error];
+            return nil;
+        }
         if (result) {
             [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-                reason:@"IDeckLinkInput::DoesSupportVideoMode failed."
-                  code:result
+                                                     reason:@"IDeckLinkInput::DoesSupportVideoMode failed."
+                                                       code:result
                     to:error];
             return nil;
         }

--- a/Sources/DLABridging/src/DLABDevice+Output.mm
+++ b/Sources/DLABridging/src/DLABDevice+Output.mm
@@ -201,8 +201,12 @@ NS_INLINE BOOL copyBufferCVtoDL(DLABDevice* self, CVPixelBufferRef pixelBuffer, 
         if (!pre1403) {
             VideoBufferGetBaseAddress(videoBuffer, &dst);
         } else {
-            IDeckLinkMutableVideoFrame_v14_2_1* videoFrame_v14_2_1 = (IDeckLinkMutableVideoFrame_v14_2_1*)videoFrame;
-            videoFrame_v14_2_1->GetBytes(&dst);
+            IDeckLinkMutableVideoFrame_v14_2_1* videoFrame_v14_2_1 = NULL;
+            HRESULT queryResult = DLABQueryInterfaceAny(videoFrame, &videoFrame_v14_2_1, IID_IDeckLinkMutableVideoFrame_v14_2_1);
+            if (queryResult == S_OK && videoFrame_v14_2_1) {
+                videoFrame_v14_2_1->GetBytes(&dst);
+            }
+            DLABReleaseIfNeeded(videoFrame_v14_2_1);
         }
         
         vImage_Buffer sourceBuffer = {0};
@@ -274,8 +278,12 @@ NS_INLINE BOOL copyPlaneCVtoDL(DLABDevice* self, CVPixelBufferRef pixelBuffer, I
         if (!pre1403) {
             VideoBufferGetBaseAddress(videoBuffer, &dst);
         } else {
-            IDeckLinkMutableVideoFrame_v14_2_1* videoFrame_v14_2_1 = (IDeckLinkMutableVideoFrame_v14_2_1*)videoFrame;
-            videoFrame_v14_2_1->GetBytes(&dst);
+            IDeckLinkMutableVideoFrame_v14_2_1* videoFrame_v14_2_1 = NULL;
+            HRESULT queryResult = DLABQueryInterfaceAny(videoFrame, &videoFrame_v14_2_1, IID_IDeckLinkMutableVideoFrame_v14_2_1);
+            if (queryResult == S_OK && videoFrame_v14_2_1) {
+                videoFrame_v14_2_1->GetBytes(&dst);
+            }
+            DLABReleaseIfNeeded(videoFrame_v14_2_1);
         }
         
         if (dst && src) {
@@ -677,29 +685,43 @@ NS_INLINE BOOL copyPlaneCVtoDL(DLABDevice* self, CVPixelBufferRef pixelBuffer, I
     IDeckLinkOutput *output = self.deckLinkOutput;
     if (output) {
         __block HRESULT result = E_FAIL;
+        __block HRESULT queryResult = S_OK;
+        __block NSString *queryFailureReason = nil;
         __block BMDDisplayMode actualMode = 0;
         __block bool supported = false;
         __block bool pre1403 = [DLABVersionChecker checkPre1403];
         __block bool pre1105 = [DLABVersionChecker checkPre1105];
         [self playback_sync:^{
             if (pre1105) {
-                IDeckLinkOutput_v11_4 *output1104 = (IDeckLinkOutput_v11_4*)output;
-                result = output1104->DoesSupportVideoMode(videoConnection,          // BMDVideoConnection = DLABVideoConnection
-                                                          displayMode,              // BMDDisplayMode = DLABDisplayMode
-                                                          pixelFormat,              // BMDPixelFormat = DLABPixelFormat
-                                                          supportedVideoModeFlag,   // BMDSupportedVideoModeFlags = DLABSupportedVideoModeFlag
-                                                          &actualMode,              // BMDDisplayMode = DLABDisplayMode
-                                                          &supported);              // bool
+                IDeckLinkOutput_v11_4 *output1104 = NULL;
+                queryResult = DLABQueryInterfaceAny(output, &output1104, IID_IDeckLinkOutput_v11_4);
+                if (queryResult == S_OK && output1104) {
+                    result = output1104->DoesSupportVideoMode(videoConnection,          // BMDVideoConnection = DLABVideoConnection
+                                                              displayMode,              // BMDDisplayMode = DLABDisplayMode
+                                                              pixelFormat,              // BMDPixelFormat = DLABPixelFormat
+                                                              supportedVideoModeFlag,   // BMDSupportedVideoModeFlags = DLABSupportedVideoModeFlag
+                                                              &actualMode,              // BMDDisplayMode = DLABDisplayMode
+                                                              &supported);              // bool
+                } else {
+                    queryFailureReason = @"DLABQueryInterfaceAny failed for IDeckLinkOutput_v11_4.";
+                }
+                DLABReleaseIfNeeded(output1104);
             } else if (pre1403) {
-                IDeckLinkOutput_v14_2_1 *output1402 = (IDeckLinkOutput_v14_2_1*)output;
-                BMDVideoOutputConversionMode convertMode = bmdNoVideoOutputConversion;
-                result = output1402->DoesSupportVideoMode(videoConnection,          // BMDVideoConnection = DLABVideoConnection
-                                                          displayMode,              // BMDDisplayMode = DLABDisplayMode
-                                                          pixelFormat,              // BMDPixelFormat = DLABPixelFormat
-                                                          convertMode,              // BMDVideoOutputConversionMode = DLABVideoOutputConversionMode
-                                                          supportedVideoModeFlag,   // BMDSupportedVideoModeFlags = DLABSupportedVideoModeFlag
-                                                          &actualMode,              // BMDDisplayMode = DLABDisplayMode
-                                                          &supported);              // bool
+                IDeckLinkOutput_v14_2_1 *output1402 = NULL;
+                queryResult = DLABQueryInterfaceAny(output, &output1402, IID_IDeckLinkOutput_v14_2_1);
+                if (queryResult == S_OK && output1402) {
+                    BMDVideoOutputConversionMode convertMode = bmdNoVideoOutputConversion;
+                    result = output1402->DoesSupportVideoMode(videoConnection,          // BMDVideoConnection = DLABVideoConnection
+                                                              displayMode,              // BMDDisplayMode = DLABDisplayMode
+                                                              pixelFormat,              // BMDPixelFormat = DLABPixelFormat
+                                                              convertMode,              // BMDVideoOutputConversionMode = DLABVideoOutputConversionMode
+                                                              supportedVideoModeFlag,   // BMDSupportedVideoModeFlags = DLABSupportedVideoModeFlag
+                                                              &actualMode,              // BMDDisplayMode = DLABDisplayMode
+                                                              &supported);              // bool
+                } else {
+                    queryFailureReason = @"DLABQueryInterfaceAny failed for IDeckLinkOutput_v14_2_1.";
+                }
+                DLABReleaseIfNeeded(output1402);
             } else {
                 BMDVideoOutputConversionMode convertMode = bmdNoVideoOutputConversion;
                 result = output->DoesSupportVideoMode(videoConnection,          // BMDVideoConnection = DLABVideoConnection
@@ -711,10 +733,17 @@ NS_INLINE BOOL copyPlaneCVtoDL(DLABDevice* self, CVPixelBufferRef pixelBuffer, I
                                                       &supported);              // bool
             }
         }];
+        if (queryFailureReason) {
+            [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
+                                                      reason:queryFailureReason
+                                                        code:queryResult
+                                                          to:error];
+            return nil;
+        }
         if (result) {
             [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-                reason:@"IDeckLinkOutput::DoesSupportVideoMode failed."
-                  code:result
+                                                      reason:@"IDeckLinkOutput::DoesSupportVideoMode failed."
+                                                        code:result
                     to:error];
             return nil;
         }

--- a/Sources/DLABridging/src/DLABDevice+Output.mm
+++ b/Sources/DLABridging/src/DLABDevice+Output.mm
@@ -735,15 +735,15 @@ NS_INLINE BOOL copyPlaneCVtoDL(DLABDevice* self, CVPixelBufferRef pixelBuffer, I
         }];
         if (queryFailureReason) {
             [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-                                                      reason:queryFailureReason
-                                                        code:queryResult
-                                                          to:error];
+                reason:queryFailureReason
+                  code:queryResult
+                    to:error];
             return nil;
         }
         if (result) {
             [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
-                                                      reason:@"IDeckLinkOutput::DoesSupportVideoMode failed."
-                                                        code:result
+                reason:@"IDeckLinkOutput::DoesSupportVideoMode failed."
+                  code:result
                     to:error];
             return nil;
         }


### PR DESCRIPTION
## Summary

This PR replaces the remaining C-style COM downcasts in the version-gated input/output paths with DLABQueryInterfaceAny and DLABReleaseIfNeeded.

### Changes
- Replaced 8 COM downcasts in DLABDevice+Input.mm and DLABDevice+Output.mm
- Preserved the existing pre1105 / pre1403 version gates
- Kept the existing error-handling flow intact
- Guarded every queried interface before dereference
- Released every queried interface in the same lexical scope

### Verification
- swift build
- swift test (29 tests, 0 failures)
