### PR TITLE
Add public 8K VideoStyle presets

### DIFF
--- a/Sources/DLABCapture/CaptureManager+Util.swift
+++ b/Sources/DLABCapture/CaptureManager+Util.swift
@@ -295,6 +295,17 @@ extension CaptureManager {
     public func videoStyleListOf(_ size:NSSize) -> [VideoStyle]? {
         var list:[VideoStyle] = [];
         
+        // DCI 8k
+        if NSEqualSizes(size, NSSize(width: 8192, height: 4320)) {
+            list = [.DCI8k_8192_4320_Full,
+                    .DCI8k_8192_4320_239, .DCI8k_8192_4320_185]
+        }
+        
+        // UHD 8k
+        if NSEqualSizes(size, NSSize(width: 7680, height: 4320)) {
+            list = [.UHD8k_7680_4320_Full]
+        }
+        
         // DCI 4k
         if NSEqualSizes(size, NSSize(width: 4096, height: 2160)) {
             list = [.DCI4k_4096_2160_Full,

--- a/Sources/DLABCapture/VideoStyle.swift
+++ b/Sources/DLABCapture/VideoStyle.swift
@@ -38,13 +38,13 @@ public enum VideoStyle : String, Sendable {
     case DCI2k_2048_1080_185  = "DCI2k 2048:1080 185"   // clap - square pixel
     case DCI2k_2048_1080_239  = "DCI2k 2048:1080 239"   // clap - square pixel
     
-    case UHD4k_3840_2160_Full  = "UHD4k 3840:2160 Full"   // square pixel
+    case UHD4k_3840_2160_Full  = "UHD4k 3840:2160 Full" // square pixel
     
     case DCI4k_4096_2160_Full = "DCI4k 4096:2160 Full"  // square pixel
     case DCI4k_4096_2160_185  = "DCI4k 4096:2160 185"   // clap - square pixel
     case DCI4k_4096_2160_239  = "DCI4k 4096:2160 239"   // clap - square pixel
     
-    case UHD8k_7680_4320_Full  = "UHD8k 7680:4320 Full"   // square pixel
+    case UHD8k_7680_4320_Full  = "UHD8k 7680:4320 Full" // square pixel
     
     case DCI8k_8192_4320_Full = "DCI8k 8192:4320 Full"  // square pixel
     case DCI8k_8192_4320_185  = "DCI8k 8192:4320 185"   // clap - square pixel
@@ -200,6 +200,7 @@ public enum VideoStyle : String, Sendable {
             encodedWidth = 7680;    encodedHeight = 4320
             visibleWidth = 7680;    visibleHeight = 4320
             aspectHorizontal = 1;   aspectVertical = 1
+        
         case .DCI8k_8192_4320_Full: // DCI8k FullAperture
             encodedWidth = 8192;    encodedHeight = 4320
             visibleWidth = 8192;    visibleHeight = 4320
@@ -212,7 +213,6 @@ public enum VideoStyle : String, Sendable {
             encodedWidth = 8192;    encodedHeight = 4320
             visibleWidth = 8192;    visibleHeight = 3432
             aspectHorizontal = 1;   aspectVertical = 1
-            
         }
         
         encW = encodedWidth

--- a/Sources/DLABCapture/VideoStyle.swift
+++ b/Sources/DLABCapture/VideoStyle.swift
@@ -44,6 +44,12 @@ public enum VideoStyle : String, Sendable {
     case DCI4k_4096_2160_185  = "DCI4k 4096:2160 185"   // clap - square pixel
     case DCI4k_4096_2160_239  = "DCI4k 4096:2160 239"   // clap - square pixel
     
+    case UHD8k_7680_4320_Full  = "UHD8k 7680:4320 Full"   // square pixel
+    
+    case DCI8k_8192_4320_Full = "DCI8k 8192:4320 Full"  // square pixel
+    case DCI8k_8192_4320_185  = "DCI8k 8192:4320 185"   // clap - square pixel
+    case DCI8k_8192_4320_239  = "DCI8k 8192:4320 239"   // clap - square pixel
+    
     /// Get width/height parameters of encodedRect, visibleRect, and aspectRatio
     ///
     /// - Parameters:
@@ -188,6 +194,23 @@ public enum VideoStyle : String, Sendable {
         case .DCI4k_4096_2160_239: // DCI4k CinemaScope 2.39:1
             encodedWidth = 4096;    encodedHeight = 2160
             visibleWidth = 4096;    visibleHeight = 1716
+            aspectHorizontal = 1;   aspectVertical = 1
+            
+        case .UHD8k_7680_4320_Full: // 8K UHD FullAperture
+            encodedWidth = 7680;    encodedHeight = 4320
+            visibleWidth = 7680;    visibleHeight = 4320
+            aspectHorizontal = 1;   aspectVertical = 1
+        case .DCI8k_8192_4320_Full: // DCI8k FullAperture
+            encodedWidth = 8192;    encodedHeight = 4320
+            visibleWidth = 8192;    visibleHeight = 4320
+            aspectHorizontal = 1;   aspectVertical = 1
+        case .DCI8k_8192_4320_185: // DCI8k Flat 1.85:1
+            encodedWidth = 8192;    encodedHeight = 4320
+            visibleWidth = 7992;    visibleHeight = 4320
+            aspectHorizontal = 1;   aspectVertical = 1
+        case .DCI8k_8192_4320_239: // DCI8k CinemaScope 2.39:1
+            encodedWidth = 8192;    encodedHeight = 4320
+            visibleWidth = 8192;    visibleHeight = 3432
             aspectHorizontal = 1;   aspectVertical = 1
             
         }

--- a/Tests/DLABCaptureTests/DLABCaptureTests.swift
+++ b/Tests/DLABCaptureTests/DLABCaptureTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import AVFoundation
 import CoreMedia
 @testable import DLABCapture
 
@@ -32,6 +33,85 @@ final class DLABCaptureTests: XCTestCase {
         //   Horizontal offset range: -7,+8, Vertical offset range: 0,0
         //   resulted (4:3) = 640:480 (pixel aspect ratio=10:11)
         //   resulted (16:9) = 853.333:480 (pixel aspect ratio=40:33)
+    }
+
+    func testVideoStyle8KPresets() throws {
+        struct Expectation {
+            let style: VideoStyle
+            let encodedSize: NSSize
+            let visibleSize: NSSize
+            let aspectRatio: NSSize
+            let cleanApertureSize: NSSize
+        }
+
+        let cases: [Expectation] = [
+            .init(style: .UHD8k_7680_4320_Full,
+                  encodedSize: NSSize(width: 7680, height: 4320),
+                  visibleSize: NSSize(width: 7680, height: 4320),
+                  aspectRatio: NSSize(width: 1, height: 1),
+                  cleanApertureSize: NSSize(width: 7680, height: 4320)),
+            .init(style: .DCI8k_8192_4320_Full,
+                  encodedSize: NSSize(width: 8192, height: 4320),
+                  visibleSize: NSSize(width: 8192, height: 4320),
+                  aspectRatio: NSSize(width: 1, height: 1),
+                  cleanApertureSize: NSSize(width: 8192, height: 4320)),
+            .init(style: .DCI8k_8192_4320_185,
+                  encodedSize: NSSize(width: 8192, height: 4320),
+                  visibleSize: NSSize(width: 7992, height: 4320),
+                  aspectRatio: NSSize(width: 1, height: 1),
+                  cleanApertureSize: NSSize(width: 7992, height: 4320)),
+            .init(style: .DCI8k_8192_4320_239,
+                  encodedSize: NSSize(width: 8192, height: 4320),
+                  visibleSize: NSSize(width: 8192, height: 3432),
+                  aspectRatio: NSSize(width: 1, height: 1),
+                  cleanApertureSize: NSSize(width: 8192, height: 3432))
+        ]
+
+        for testCase in cases {
+            XCTAssertEqual(testCase.style.encodedSize(), testCase.encodedSize)
+            XCTAssertEqual(testCase.style.visibleSize(), testCase.visibleSize)
+            XCTAssertEqual(testCase.style.aspectRatio(), testCase.aspectRatio)
+
+            let settings = testCase.style.settings(hOffset: 0, vOffset: 0)
+            XCTAssertEqual((settings[AVVideoWidthKey] as? NSNumber)?.doubleValue, testCase.encodedSize.width)
+            XCTAssertEqual((settings[AVVideoHeightKey] as? NSNumber)?.doubleValue, testCase.encodedSize.height)
+
+            let cleanAperture = try XCTUnwrap(settings[AVVideoCleanApertureKey] as? [String: Any])
+            XCTAssertEqual((cleanAperture[AVVideoCleanApertureWidthKey] as? NSNumber)?.doubleValue, testCase.cleanApertureSize.width)
+            XCTAssertEqual((cleanAperture[AVVideoCleanApertureHeightKey] as? NSNumber)?.doubleValue, testCase.cleanApertureSize.height)
+            XCTAssertEqual((cleanAperture[AVVideoCleanApertureHorizontalOffsetKey] as? NSNumber)?.doubleValue, 0)
+            XCTAssertEqual((cleanAperture[AVVideoCleanApertureVerticalOffsetKey] as? NSNumber)?.doubleValue, 0)
+
+            let pixelAspectRatio = try XCTUnwrap(settings[AVVideoPixelAspectRatioKey] as? [String: Any])
+            XCTAssertEqual((pixelAspectRatio[AVVideoPixelAspectRatioHorizontalSpacingKey] as? NSNumber)?.doubleValue, 1)
+            XCTAssertEqual((pixelAspectRatio[AVVideoPixelAspectRatioVerticalSpacingKey] as? NSNumber)?.doubleValue, 1)
+
+            let colorProperties = try XCTUnwrap(settings[AVVideoColorPropertiesKey] as? [String: Any])
+            XCTAssertEqual(colorProperties[AVVideoColorPrimariesKey] as? String, AVVideoColorPrimaries_ITU_R_2020)
+            XCTAssertEqual(colorProperties[AVVideoTransferFunctionKey] as? String, AVVideoTransferFunction_ITU_R_709_2)
+            XCTAssertEqual(colorProperties[AVVideoYCbCrMatrixKey] as? String, AVVideoYCbCrMatrix_ITU_R_2020)
+        }
+    }
+
+    func testCaptureManagerVideoStyleListIncludes8KPresets() throws {
+        let manager = CaptureManager()
+
+        XCTAssertEqual(
+            manager.videoStyleListOf(NSSize(width: 7680, height: 4320)),
+            [.UHD8k_7680_4320_Full]
+        )
+
+        XCTAssertEqual(
+            manager.videoStyleListOf(NSSize(width: 8192, height: 4320)),
+            [.DCI8k_8192_4320_Full, .DCI8k_8192_4320_239, .DCI8k_8192_4320_185]
+        )
+
+        XCTAssertEqual(
+            manager.videoStyleListOf(NSSize(width: 3840, height: 2160)),
+            [.UHD4k_3840_2160_Full]
+        )
+
+        XCTAssertNil(manager.videoStyleListOf(NSSize(width: 123, height: 456)))
     }
     
     func testDeviceList() throws {


### PR DESCRIPTION
## Summary

Add public 8K `VideoStyle` presets and expose them through `videoStyleListOf(_:)`.

### Changes
- Added 4 new 8K `VideoStyle` enum cases
- Extended `VideoStyle.parse(...)` with the 8K size mappings
- Added 8K entries to `videoStyleListOf(_:)` before the DCI 4K block
- Left the existing 8K display-mode cleanup untouched

### Verification
- `swift build`
- `swift test` (29 tests, 0 failures)
