### PR TITLE
Fix ppv null guards in QueryInterface

### DIFF
--- a/Sources/DLABridgingCpp/src/DLABInputCallback.mm
+++ b/Sources/DLABridgingCpp/src/DLABInputCallback.mm
@@ -35,6 +35,7 @@ HRESULT DLABInputCallback::VideoInputFrameArrived(IDeckLinkVideoInputFrame* vide
 
 HRESULT DLABInputCallback::QueryInterface(REFIID iid, LPVOID *ppv)
 {
+    if (!ppv) return E_POINTER;
     *ppv = NULL;
     CFUUIDBytes iunknown = CFUUIDGetUUIDBytes(IUnknownUUID);
     if (memcmp(&iid, &iunknown, sizeof(REFIID)) == 0) {

--- a/Sources/DLABridgingCpp/src/DLABNotificationCallback.mm
+++ b/Sources/DLABridgingCpp/src/DLABNotificationCallback.mm
@@ -21,6 +21,7 @@ HRESULT DLABNotificationCallback::Notify(BMDNotifications topic, uint64_t param1
 
 HRESULT DLABNotificationCallback::QueryInterface(REFIID iid, LPVOID *ppv)
 {
+    if (!ppv) return E_POINTER;
     *ppv = NULL;
     CFUUIDBytes iunknown = CFUUIDGetUUIDBytes(IUnknownUUID);
     if (memcmp(&iid, &iunknown, sizeof(REFIID)) == 0) {

--- a/Sources/DLABridgingCpp/src/DLABOutputCallback.mm
+++ b/Sources/DLABridgingCpp/src/DLABOutputCallback.mm
@@ -46,6 +46,7 @@ HRESULT DLABOutputCallback::RenderAudioSamples(bool preroll)
 
 HRESULT DLABOutputCallback::QueryInterface(REFIID iid, LPVOID *ppv)
 {
+    if (!ppv) return E_POINTER;
     *ppv = NULL;
     CFUUIDBytes iunknown = CFUUIDGetUUIDBytes(IUnknownUUID);
     if (memcmp(&iid, &iunknown, sizeof(REFIID)) == 0) {


### PR DESCRIPTION
## Summary
- Add `if (!ppv) return E_POINTER;` guards to the three DLABridgingCpp QueryInterface implementations.
- Preserve existing interface matching and reference counting behavior for valid pointers.

## Validation
- Build succeeded
- All 31 tests passed
