### PR TITLE
Fix double release in instantPlaybackOfPixelBuffer

### DIFF
--- a/Sources/DLABridging/src/DLABDevice+Output.mm
+++ b/Sources/DLABridging/src/DLABDevice+Output.mm
@@ -1180,9 +1180,6 @@ static DLABFrameMetadata * processCallbacks(DLABDevice *self, IDeckLinkMutableVi
     if (!result) {
         return YES;
     } else {
-        if (outFrame) {
-            [self.outputVideoFramePool releaseFrame:outFrame];
-        }
         
         [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
             reason:@"IDeckLinkOutput::DisplayVideoFrameSync failed."


### PR DESCRIPTION
## Summary
- Fix the instantPlaybackOfPixelBuffer double-release in RB-02.

## Validation
- Build succeeded
- All 31 tests passed
