### PR TITLE
Replay local work updates into work

### DIFF
--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -1332,6 +1332,8 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                 catch {
                     audioPreviewError = error
                     printVerbose("ERROR:CaptureManager.\(#function) - audio preview aqStart failed: \(error.localizedDescription)")
+                    let _ = takeAudioPreviewForDisposal()
+                    try? preview.aqDispose()
                 }
             }
         }

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -1299,6 +1299,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     private func processCapturedAudioSampleAsync(_ info: UnsafeSampleBufferInfo) async {
         guard running else { return }
         let sampleBuffer = info.sampleBuffer
+        var audioPreviewStateToDispose: AudioPreviewState? = nil
         
         if let writer = currentAppendWriter() {
             let wrapper = UnsafeSampleBufferWrapper(sampleBuffer: sampleBuffer)
@@ -1332,9 +1333,19 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                 catch {
                     audioPreviewError = error
                     printVerbose("ERROR:CaptureManager.\(#function) - audio preview aqStart failed: \(error.localizedDescription)")
-                    let _ = takeAudioPreviewForDisposal()
-                    try? preview.aqDispose()
+                    audioPreviewStateToDispose = takeAudioPreviewForDisposal()
                 }
+            }
+        }
+        
+        if let audioPreviewStateToDispose {
+            do {
+                try await finishDisposingAudioPreview(
+                    audioPreviewStateToDispose,
+                    teardown: { preview in try preview.aqDispose() }
+                )
+            } catch {
+                printVerbose("ERROR:CaptureManager.\(#function) - audio preview aqDispose failed: \(error.localizedDescription)")
             }
         }
     }

--- a/Sources/DLABCapture/CaptureWriter.swift
+++ b/Sources/DLABCapture/CaptureWriter.swift
@@ -555,7 +555,7 @@ actor CaptureWriter {
                 traceStartup("open-session-total \(elapsedMS(from: startAt))ms")
             } catch {
                 avAssetWriter.cancelWriting()
-                self.avAssetWriter = nil
+                cleanUp()
                 throw error
             }
         } else {

--- a/Sources/DLABCapture/CaptureWriter.swift
+++ b/Sources/DLABCapture/CaptureWriter.swift
@@ -527,31 +527,37 @@ actor CaptureWriter {
             // Apply movieTimeScale
             avAssetWriter.movieTimeScale = sampleTimescale
             
-            // Prepare AVAssetWriterInput(s)
-            let prepareInputStart = CFAbsoluteTimeGetCurrent()
-            try prepareInputMedia()
-            traceStartup("prepare-input-media \(elapsedMS(from: prepareInputStart))ms")
-            
-            // Register AVAssetWriterInput(s)
-            let registerInputStart = CFAbsoluteTimeGetCurrent()
-            try registerInputMedia()
-            traceStartup("register-input-media \(elapsedMS(from: registerInputStart))ms")
-            
-            // Start writing session
-            let startWritingStart = CFAbsoluteTimeGetCurrent()
-            let valid = avAssetWriter.startWriting()
-            traceStartup("start-writing \(elapsedMS(from: startWritingStart))ms")
-            if !valid {
-                if let error = avAssetWriter.error {
-                    let reason = error.localizedDescription
-                    throw CaptureWriterError.unexpectedErrorWhileOpeningSession(reason)
-                } else {
-                    let statusStr = self.descriptionForStatus(avAssetWriter.status)
-                    let reason = "AVAssetWriter did not start successfully. (\(statusStr))"
-                    throw CaptureWriterError.unexpectedErrorWhileOpeningSession(reason)
+            do {
+                // Prepare AVAssetWriterInput(s)
+                let prepareInputStart = CFAbsoluteTimeGetCurrent()
+                try prepareInputMedia()
+                traceStartup("prepare-input-media \(elapsedMS(from: prepareInputStart))ms")
+                
+                // Register AVAssetWriterInput(s)
+                let registerInputStart = CFAbsoluteTimeGetCurrent()
+                try registerInputMedia()
+                traceStartup("register-input-media \(elapsedMS(from: registerInputStart))ms")
+                
+                // Start writing session
+                let startWritingStart = CFAbsoluteTimeGetCurrent()
+                let valid = avAssetWriter.startWriting()
+                traceStartup("start-writing \(elapsedMS(from: startWritingStart))ms")
+                if !valid {
+                    if let error = avAssetWriter.error {
+                        let reason = error.localizedDescription
+                        throw CaptureWriterError.unexpectedErrorWhileOpeningSession(reason)
+                    } else {
+                        let statusStr = self.descriptionForStatus(avAssetWriter.status)
+                        let reason = "AVAssetWriter did not start successfully. (\(statusStr))"
+                        throw CaptureWriterError.unexpectedErrorWhileOpeningSession(reason)
+                    }
                 }
+                traceStartup("open-session-total \(elapsedMS(from: startAt))ms")
+            } catch {
+                avAssetWriter.cancelWriting()
+                self.avAssetWriter = nil
+                throw error
             }
-            traceStartup("open-session-total \(elapsedMS(from: startAt))ms")
         } else {
             let reason = "AVAssetWriter is not available."
             throw CaptureWriterError.assetWriterIsNotAvailable(reason)

--- a/Sources/DLABridging/src/DLABDevice+Output.mm
+++ b/Sources/DLABridging/src/DLABDevice+Output.mm
@@ -1180,7 +1180,6 @@ static DLABFrameMetadata * processCallbacks(DLABDevice *self, IDeckLinkMutableVi
     if (!result) {
         return YES;
     } else {
-        
         [self post:[NSString stringWithFormat:@"%s (%d)", __PRETTY_FUNCTION__, __LINE__]
             reason:@"IDeckLinkOutput::DisplayVideoFrameSync failed."
               code:result


### PR DESCRIPTION
This PR replays the local work updates into `work`:
- Clean up partial AVAssetWriter on openSession failure
- Recover audio preview after aqStart failure
- cosmetics

`work` has been reset to `origin/work` so this branch carries the pending updates for merge.