### PR TITLE
Fix M-01, M-02, M-03, M-04, M-06, and M-14 in DLAB SPM

### DIFF
--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -221,6 +221,10 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         var stopError: (any Error)? = nil
         var audioPreviewError: (any Error)? = nil
         var previewError: (any Error)? = nil
+        // M-01: writer.appendSampleBuffer failure observability
+        var lastAppendError: (any Error)? = nil
+        var appendErrorCount: Int = 0
+        var appendErrorMediaType: String? = nil
         var currentDevice: DLABDevice? = nil
         var audioCaptureEnabled: Bool = false
         var videoCaptureEnabled: Bool = false
@@ -582,7 +586,34 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     public func clearPreviewError() {
         withRuntimeState { $0.previewError = nil }
     }
-    
+
+    /// Last `writer.appendSampleBuffer` failure (audio / video / timecode), if any.
+    /// Overwritten on each new failure; not cleared automatically.
+    /// Use ``clearLastAppendError()`` to reset after handling.
+    public private(set) var lastAppendError: (any Error)? {
+        get { runtimeStateValue(\.lastAppendError) }
+        set { withRuntimeState { $0.lastAppendError = newValue } }
+    }
+
+    /// Cumulative count of `writer.appendSampleBuffer` failures since the last clear.
+    public var appendErrorCount: Int {
+        get { runtimeStateValue(\.appendErrorCount) }
+    }
+
+    /// Media type string ("audio" / "video" / "timecode") of the most recent append failure.
+    public var appendErrorMediaType: String? {
+        get { runtimeStateValue(\.appendErrorMediaType) }
+    }
+
+    /// Clear the last append error and reset the cumulative counter.
+    public func clearLastAppendError() {
+        withRuntimeState {
+            $0.lastAppendError = nil
+            $0.appendErrorCount = 0
+            $0.appendErrorMediaType = nil
+        }
+    }
+
     /// Optional callback for non-fatal `CaptureWriter` diagnostics during fallback cleanup.
     public var captureWriterDiagnosticHandler: (@Sendable (CaptureWriterDiagnostic) -> Void)? = nil
     
@@ -1507,6 +1538,14 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                 try await writer.appendSampleBuffer(wrapper: wrapper, mediaType: .audio)
             } catch {
                 printVerbose("ERROR:CaptureManager.\(#function) - audio append failed: \(error.localizedDescription)")
+                // M-01: record append failure for observability (getter only;
+                // no new CaptureWriterDiagnostic case, to avoid a source-breaking
+                // addition to the public enum).
+                withRuntimeState { state in
+                    state.lastAppendError = error
+                    state.appendErrorCount += 1
+                    state.appendErrorMediaType = "audio"
+                }
             }
         }
         withAudioPreview { preview in
@@ -1563,6 +1602,14 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                 try await writer.appendSampleBuffer(wrapper: wrapper, mediaType: .video)
             } catch {
                 printVerbose("ERROR:CaptureManager.\(#function) - video append failed: \(error.localizedDescription)")
+                // M-01: record append failure for observability (getter only;
+                // no new CaptureWriterDiagnostic case, to avoid a source-breaking
+                // addition to the public enum).
+                withRuntimeState { state in
+                    state.lastAppendError = error
+                    state.appendErrorCount += 1
+                    state.appendErrorMediaType = "video"
+                }
             }
         }
         
@@ -1583,9 +1630,17 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                             try await writer.appendSampleBuffer(wrapper: wrapper, mediaType: .timecode)
                         } catch {
                             printVerbose("ERROR:CaptureManager.\(#function) - device timecode append failed: \(error.localizedDescription)")
+                            // M-01: record append failure for observability (getter only;
+                            // no new CaptureWriterDiagnostic case, to avoid a source-breaking
+                            // addition to the public enum).
+                            withRuntimeState { state in
+                                state.lastAppendError = error
+                                state.appendErrorCount += 1
+                                state.appendErrorMediaType = "timecode"
+                            }
                         }
                     }
-                    
+
                     // source provides timecode
                     if timecodeReady == false {
                         timecodeReady = true
@@ -1604,9 +1659,17 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                             try await writer.appendSampleBuffer(wrapper: wrapper, mediaType: .timecode)
                         } catch {
                             printVerbose("ERROR:CaptureManager.\(#function) - core audio timecode append failed: \(error.localizedDescription)")
+                            // M-01: record append failure for observability (getter only;
+                            // no new CaptureWriterDiagnostic case, to avoid a source-breaking
+                            // addition to the public enum).
+                            withRuntimeState { state in
+                                state.lastAppendError = error
+                                state.appendErrorCount += 1
+                                state.appendErrorMediaType = "timecode"
+                            }
                         }
                     }
-                    
+
                     // source provides timecode
                     if timecodeReady == false {
                         timecodeReady = true

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -926,7 +926,12 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     /// Stop capture session
     @discardableResult
     public func captureStopAsync() async -> Bool {
-        if let device = currentDevice, running == true {
+        // M-02: atomic snapshot of (currentDevice, running) under single lock
+        // to avoid TOCTOU between the two getter calls.
+        let snapshot = withRuntimeState { state in
+            (currentDevice: state.currentDevice, running: state.running)
+        }
+        if let device = snapshot.currentDevice, snapshot.running {
             stopError = nil
             if recording {
                 await recordToggleAsync() // actor isolated (writer)

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -759,11 +759,16 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     public var timecodeSource: TimecodeType? {
         get { timecodeSourceLock.value }
         set {
-            if running {
-                printVerbose("WARNING:CaptureManager.timecodeSource - change requested while capture is running; ignoring (existing value preserved)")
-                return
+            let shouldIgnore = withRuntimeState { state in
+                if state.running {
+                    return true
+                }
+                timecodeSourceLock.value = newValue
+                return false
             }
-            timecodeSourceLock.value = newValue
+            if shouldIgnore {
+                printVerbose("WARNING:CaptureManager.timecodeSource - change requested while capture is running; ignoring (existing value preserved)")
+            }
         }
     }
     

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -703,7 +703,23 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     public var timecodeFormatType : CMTimeCodeFormatType = kCMTimeCodeFormatType_TimeCode32
     
     /// Validate if source provides timecode of specified type. Set before ``captureStartAsync()``.
-    public var timecodeSource :TimecodeType? = nil
+    ///
+    /// M-14: backed by a `LockedOptionalValueBox` so callback / async code can read
+    /// the value safely. The setter enforces the set-before-capture contract:
+    /// when `running == true`, assignment is **ignored** with a `printVerbose` warning
+    /// (existing value is preserved). This protects against in-flight timecode
+    /// processing being desynchronized from `currentTimecodeHelper()`.
+    private let timecodeSourceLock = LockedOptionalValueBox<TimecodeType>()
+    public var timecodeSource: TimecodeType? {
+        get { timecodeSourceLock.value }
+        set {
+            if running {
+                printVerbose("WARNING:CaptureManager.timecodeSource - change requested while capture is running; ignoring (existing value preserved)")
+                return
+            }
+            timecodeSourceLock.value = newValue
+        }
+    }
     
     /* ============================================ */
     // MARK: - properties - Capturing ancillary data

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -562,7 +562,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         get { runtimeStateValue(\.stopError) }
         set { withRuntimeState { $0.stopError = newValue } }
     }
-
+    
     /// Error from the last `captureStartAsync()` call (or its rollback), if start failed.
     /// Overwritten on each new failure; not cleared automatically.
     /// Use ``clearLastStartError()`` to reset after handling.
@@ -570,7 +570,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         get { runtimeStateValue(\.lastStartError) }
         set { withRuntimeState { $0.lastStartError = newValue } }
     }
-
+    
     /// Clear the last start error.
     public func clearLastStartError() {
         withRuntimeState { $0.lastStartError = nil }
@@ -601,7 +601,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     public func clearPreviewError() {
         withRuntimeState { $0.previewError = nil }
     }
-
+    
     /// Last `writer.appendSampleBuffer` failure (audio / video / timecode), if any.
     /// Overwritten on each new failure; not cleared automatically.
     /// Use ``clearLastAppendError()`` to reset after handling.
@@ -609,17 +609,17 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         get { runtimeStateValue(\.lastAppendError) }
         set { withRuntimeState { $0.lastAppendError = newValue } }
     }
-
+    
     /// Cumulative count of `writer.appendSampleBuffer` failures since the last clear.
     public var appendErrorCount: Int {
         get { runtimeStateValue(\.appendErrorCount) }
     }
-
+    
     /// Media type string ("audio" / "video" / "timecode") of the most recent append failure.
     public var appendErrorMediaType: String? {
         get { runtimeStateValue(\.appendErrorMediaType) }
     }
-
+    
     /// Clear the last append error and reset the cumulative counter.
     public func clearLastAppendError() {
         withRuntimeState {
@@ -628,7 +628,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
             $0.appendErrorMediaType = nil
         }
     }
-
+    
     /// Optional callback for non-fatal `CaptureWriter` diagnostics during fallback cleanup.
     public var captureWriterDiagnosticHandler: (@Sendable (CaptureWriterDiagnostic) -> Void)? = nil
     
@@ -1091,7 +1091,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     private func rollbackCaptureStart(on device: DLABDevice) async {
         device.inputDelegate = nil
         clearInputAncillaryPacketHandler(from: device)
-
+        
         if audioCaptureEnabled {
             do {
                 try device.disableAudioInput()
@@ -1112,7 +1112,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                 withRuntimeState { $0.lastStartError = error }
             }
         }
-
+        
         if let videoPreview = videoPreview {
             await MainActor.run {
                 videoPreview.shutdown()
@@ -1127,7 +1127,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                 withRuntimeState { $0.lastStartError = error }
             }
         }
-
+        
         do {
             try await disposeAudioPreview()
         } catch let error as NSError {
@@ -1135,7 +1135,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
             // M-03: surface rollback failure
             withRuntimeState { $0.lastStartError = error }
         }
-
+        
         timecodeReady = false
         clearTimecodeHelper()
         running = false
@@ -1703,7 +1703,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                             }
                         }
                     }
-
+                    
                     // source provides timecode
                     if timecodeReady == false {
                         timecodeReady = true
@@ -1732,7 +1732,7 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                             }
                         }
                     }
-
+                    
                     // source provides timecode
                     if timecodeReady == false {
                         timecodeReady = true

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -221,6 +221,8 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
         var stopError: (any Error)? = nil
         var audioPreviewError: (any Error)? = nil
         var previewError: (any Error)? = nil
+        // M-03: captureStartAsync / rollbackCaptureStart failure observability
+        var lastStartError: (any Error)? = nil
         var currentDevice: DLABDevice? = nil
         var audioCaptureEnabled: Bool = false
         var videoCaptureEnabled: Bool = false
@@ -555,6 +557,19 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     public private(set) var stopError: (any Error)? {
         get { runtimeStateValue(\.stopError) }
         set { withRuntimeState { $0.stopError = newValue } }
+    }
+
+    /// Error from the last `captureStartAsync()` call (or its rollback), if start failed.
+    /// Overwritten on each new failure; not cleared automatically.
+    /// Use ``clearLastStartError()`` to reset after handling.
+    public private(set) var lastStartError: (any Error)? {
+        get { runtimeStateValue(\.lastStartError) }
+        set { withRuntimeState { $0.lastStartError = newValue } }
+    }
+
+    /// Clear the last start error.
+    public func clearLastStartError() {
+        withRuntimeState { $0.lastStartError = nil }
     }
     
     /// Last audio preview failure (enqueue/aqPrime/aqStart), if any.
@@ -913,12 +928,22 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                 }
             } catch let error as NSError {
                 printVerbose("ERROR:\(error.domain)(\(error.code)): \(error.localizedFailureReason ?? "unknown reason")")
+                // M-03: record start failure for observability
+                withRuntimeState { $0.lastStartError = error }
                 if let device = currentDevice {
                     await rollbackCaptureStart(on: device)
                 }
             }
         }  else {
             printVerbose("ERROR: device is not ready")
+            // M-03: there is no thrown Error to surface in the precondition
+            // path (currentDevice nil, or device.isReady == false), so
+            // synthesize one in the shared DLABCapture error domain so
+            // callers reading lastStartError can observe why start failed.
+            let preconditionError = createError(OSStatus(-1),
+                                                "CaptureManager.captureStartAsync",
+                                                "device is not ready")
+            withRuntimeState { $0.lastStartError = preconditionError }
         }
         return false
     }
@@ -1005,13 +1030,15 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
     private func rollbackCaptureStart(on device: DLABDevice) async {
         device.inputDelegate = nil
         clearInputAncillaryPacketHandler(from: device)
-        
+
         if audioCaptureEnabled {
             do {
                 try device.disableAudioInput()
                 audioCaptureEnabled = false
             } catch let error as NSError {
                 printVerbose("ERROR:CaptureManager.rollbackCaptureStart - disableAudioInput failed: \(error.domain)(\(error.code)): \(error.localizedFailureReason ?? error.localizedDescription)")
+                // M-03: surface rollback failure
+                withRuntimeState { $0.lastStartError = error }
             }
         }
         if videoCaptureEnabled {
@@ -1020,9 +1047,11 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                 videoCaptureEnabled = false
             } catch let error as NSError {
                 printVerbose("ERROR:CaptureManager.rollbackCaptureStart - disableVideoInput failed: \(error.domain)(\(error.code)): \(error.localizedFailureReason ?? error.localizedDescription)")
+                // M-03: surface rollback failure
+                withRuntimeState { $0.lastStartError = error }
             }
         }
-        
+
         if let videoPreview = videoPreview {
             await MainActor.run {
                 videoPreview.shutdown()
@@ -1033,15 +1062,19 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                 try await attachInputScreenPreview(to: nil)
             } catch let error as NSError {
                 printVerbose("ERROR:CaptureManager.rollbackCaptureStart - attachInputScreenPreview failed: \(error.domain)(\(error.code)): \(error.localizedFailureReason ?? error.localizedDescription)")
+                // M-03: surface rollback failure
+                withRuntimeState { $0.lastStartError = error }
             }
         }
-        
+
         do {
             try await disposeAudioPreview()
         } catch let error as NSError {
             printVerbose("ERROR:CaptureManager.rollbackCaptureStart - disposeAudioPreview failed: \(error.domain)(\(error.code)): \(error.localizedFailureReason ?? error.localizedDescription)")
+            // M-03: surface rollback failure
+            withRuntimeState { $0.lastStartError = error }
         }
-        
+
         timecodeReady = false
         clearTimecodeHelper()
         running = false

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -988,16 +988,9 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
             }
         }  else {
             let snapshot = withRuntimeState { state in
-                (hasDevice: state.currentDevice != nil, running: state.running)
+                state.running
             }
-            let reason: String
-            if snapshot.running {
-                reason = "capture is already running"
-            } else if !snapshot.hasDevice {
-                reason = "device is not ready"
-            } else {
-                reason = "device is not ready"
-            }
+            let reason = snapshot ? "capture is already running" : "device is not ready"
             printVerbose("ERROR: \(reason)")
             // M-03: there is no thrown Error to surface in this precondition
             // path (missing currentDevice, or capture already running), so

--- a/Sources/DLABCapture/CaptureManager.swift
+++ b/Sources/DLABCapture/CaptureManager.swift
@@ -987,14 +987,25 @@ public class CaptureManager: NSObject, DLABInputCaptureDelegate {
                 }
             }
         }  else {
-            printVerbose("ERROR: device is not ready")
-            // M-03: there is no thrown Error to surface in the precondition
-            // path (currentDevice nil, or device.isReady == false), so
+            let snapshot = withRuntimeState { state in
+                (hasDevice: state.currentDevice != nil, running: state.running)
+            }
+            let reason: String
+            if snapshot.running {
+                reason = "capture is already running"
+            } else if !snapshot.hasDevice {
+                reason = "device is not ready"
+            } else {
+                reason = "device is not ready"
+            }
+            printVerbose("ERROR: \(reason)")
+            // M-03: there is no thrown Error to surface in this precondition
+            // path (missing currentDevice, or capture already running), so
             // synthesize one in the shared DLABCapture error domain so
             // callers reading lastStartError can observe why start failed.
             let preconditionError = createError(OSStatus(-1),
                                                 "CaptureManager.captureStartAsync",
-                                                "device is not ready")
+                                                reason)
             withRuntimeState { $0.lastStartError = preconditionError }
         }
         return false

--- a/Sources/DLABCapture/CaptureTimecodeHelper.swift
+++ b/Sources/DLABCapture/CaptureTimecodeHelper.swift
@@ -148,13 +148,19 @@ final class CaptureTimecodeHelper: NSObject, @unchecked Sendable {
         let smpteTimeData = CMGetAttachment(sampleBuffer,
                                             key: smpteTimeKey as CFString,
                                             attachmentModeOut: nil)
-        
+
         // Create SMPTETime struct from sampleBuffer attachment
         var smpteTime: CVSMPTETime? = nil
         if let smpteTimeData = smpteTimeData as? NSData {
+            // M-04: guard against undersized attachment to prevent OOB read in load(as:)
+            // NSData.length < MemoryLayout<CVSMPTETime>.size would cause
+            // UnsafeRawPointer.load precondition failure / OOB read.
+            guard smpteTimeData.length >= MemoryLayout<CVSMPTETime>.size else {
+                return nil
+            }
             smpteTime = smpteTimeData.bytes.load(as: CVSMPTETime.self)
         }
-        
+
         return smpteTime
     }
     

--- a/Sources/DLABCapture/CaptureTimecodeHelper.swift
+++ b/Sources/DLABCapture/CaptureTimecodeHelper.swift
@@ -154,11 +154,12 @@ final class CaptureTimecodeHelper: NSObject, @unchecked Sendable {
         if let smpteTimeData = smpteTimeData as? NSData {
             // M-04: guard against undersized attachment to prevent OOB read in load(as:)
             // NSData.length < MemoryLayout<CVSMPTETime>.size would cause
-            // UnsafeRawPointer.load precondition failure / OOB read.
+            // UnsafeRawPointer.load precondition failure / OOB read. Also use
+            // loadUnaligned(as:) because NSData.bytes does not guarantee alignment.
             guard smpteTimeData.length >= MemoryLayout<CVSMPTETime>.size else {
                 return nil
             }
-            smpteTime = smpteTimeData.bytes.load(as: CVSMPTETime.self)
+            smpteTime = smpteTimeData.bytes.loadUnaligned(as: CVSMPTETime.self)
         }
 
         return smpteTime
@@ -266,5 +267,9 @@ final class CaptureTimecodeHelper: NSObject, @unchecked Sendable {
                                                    quanta: UInt32,
                                                    tcType: UInt32) -> CMBlockBuffer? {
         prepareTimeCodeDataBuffer(smpteTime, sizes, quanta, tcType)
+    }
+
+    internal func testingExtractCVSMPTETime(from sampleBuffer: CMSampleBuffer) -> CVSMPTETime? {
+        extractCVSMPTETime(from: sampleBuffer)
     }
 }

--- a/Sources/DLABCapture/CaptureTimecodeHelper.swift
+++ b/Sources/DLABCapture/CaptureTimecodeHelper.swift
@@ -148,7 +148,7 @@ final class CaptureTimecodeHelper: NSObject, @unchecked Sendable {
         let smpteTimeData = CMGetAttachment(sampleBuffer,
                                             key: smpteTimeKey as CFString,
                                             attachmentModeOut: nil)
-
+        
         // Create SMPTETime struct from sampleBuffer attachment
         var smpteTime: CVSMPTETime? = nil
         if let smpteTimeData = smpteTimeData as? NSData {
@@ -161,7 +161,7 @@ final class CaptureTimecodeHelper: NSObject, @unchecked Sendable {
             }
             smpteTime = smpteTimeData.bytes.loadUnaligned(as: CVSMPTETime.self)
         }
-
+        
         return smpteTime
     }
     
@@ -268,7 +268,7 @@ final class CaptureTimecodeHelper: NSObject, @unchecked Sendable {
                                                    tcType: UInt32) -> CMBlockBuffer? {
         prepareTimeCodeDataBuffer(smpteTime, sizes, quanta, tcType)
     }
-
+    
     internal func testingExtractCVSMPTETime(from sampleBuffer: CMSampleBuffer) -> CVSMPTETime? {
         extractCVSMPTETime(from: sampleBuffer)
     }

--- a/Sources/DLABCapture/CaptureWriter.swift
+++ b/Sources/DLABCapture/CaptureWriter.swift
@@ -404,12 +404,23 @@ actor CaptureWriter {
     /* ============================================ */
     
     /// Start writing session
+    ///
     /// - Note: If any error occurs, it will be stored in `internalError`.
+    ///
+    /// - Warning: `openSession()` is **not** intended to be called concurrently from
+    ///   multiple tasks. Because `openSession()` can suspend in `await closeSession()`
+    ///   (see H-06 close-and-restart branch below), callers must serialize session
+    ///   lifecycle transitions externally. The actor model guarantees that two
+    ///   `openSession()` invocations on the same instance are not literally running
+    ///   at the same time, but their reentrancy via the `await closeSession()` point
+    ///   can still interleave their effects on `isRecording` / `startRecording()`.
     public func openSession() async {
         openSessionStartedAt = CFAbsoluteTimeGetCurrent()
         loggedFirstVideoAppend = false
-        
+
         // H-06: If a previous session is still open, close it first to recover writer state.
+        // M-06: This `await closeSession()` is a reentrancy point; concurrent callers
+        //       of openSession() can interleave here. See openSession() contract.
         if isRecording {
             // Capture any in-flight write error from the previous session BEFORE
             // closeSession() resets internalError at its start.

--- a/Sources/DLABCapture/CaptureWriter.swift
+++ b/Sources/DLABCapture/CaptureWriter.swift
@@ -417,7 +417,7 @@ actor CaptureWriter {
     public func openSession() async {
         openSessionStartedAt = CFAbsoluteTimeGetCurrent()
         loggedFirstVideoAppend = false
-
+        
         // H-06: If a previous session is still open, close it first to recover writer state.
         // M-06: This `await closeSession()` is a reentrancy point; concurrent callers
         //       of openSession() can interleave here. See openSession() contract.

--- a/Tests/DLABCaptureTests/DLABCaptureTests.swift
+++ b/Tests/DLABCaptureTests/DLABCaptureTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import AVFoundation
+import AudioToolbox
 import CoreMedia
 @testable import DLABCapture
 
@@ -184,6 +185,22 @@ final class DLABCaptureTests: XCTestCase {
         XCTAssertNil(dataBuffer)
     }
 
+    func testCaptureTimecodeHelperReturnsNilForUndersizedSMPTEAttachment() throws {
+        let helper = CaptureTimecodeHelper(formatType: kCMTimeCodeFormatType_TimeCode32)
+        let sampleBuffer = try makeAudioSampleBufferForTests()
+        let undersizedData = Data(repeating: 0, count: MemoryLayout<CVSMPTETime>.size - 1) as NSData
+
+        CMSetAttachment(
+            sampleBuffer,
+            key: "com.apple.cmio.buffer_attachment.core_audio_smpte_time" as CFString,
+            value: undersizedData,
+            attachmentMode: kCMAttachmentMode_ShouldPropagate
+        )
+
+        XCTAssertNil(helper.testingExtractCVSMPTETime(from: sampleBuffer))
+        XCTAssertNil(helper.createTimeCodeSample(from: sampleBuffer))
+    }
+
     func testCaptureManagerDisposeAudioPreviewWaitsForInFlightUse() async throws {
         let manager = CaptureManager()
         let preview = CaptureAudioPreview.TestingDouble()
@@ -353,4 +370,84 @@ final class DLABCaptureTests: XCTestCase {
 
         await fulfillment(of: [startExpectation, timeoutExpectation], timeout: 1.0)
     }
+}
+
+private func makeAudioSampleBufferForTests() throws -> CMSampleBuffer {
+    var asbd = AudioStreamBasicDescription(
+        mSampleRate: 48_000,
+        mFormatID: kAudioFormatLinearPCM,
+        mFormatFlags: kLinearPCMFormatFlagIsSignedInteger | kLinearPCMFormatFlagIsPacked,
+        mBytesPerPacket: 2,
+        mFramesPerPacket: 1,
+        mBytesPerFrame: 2,
+        mChannelsPerFrame: 1,
+        mBitsPerChannel: 16,
+        mReserved: 0
+    )
+
+    var formatDescription: CMAudioFormatDescription?
+    let formatStatus = CMAudioFormatDescriptionCreate(
+        allocator: kCFAllocatorDefault,
+        asbd: &asbd,
+        layoutSize: 0,
+        layout: nil,
+        magicCookieSize: 0,
+        magicCookie: nil,
+        extensions: nil,
+        formatDescriptionOut: &formatDescription
+    )
+    guard formatStatus == noErr, let formatDescription else {
+        throw NSError(domain: "DLABCaptureTests", code: Int(formatStatus))
+    }
+
+    var blockBuffer: CMBlockBuffer?
+    let blockStatus = CMBlockBufferCreateWithMemoryBlock(
+        allocator: kCFAllocatorDefault,
+        memoryBlock: nil,
+        blockLength: 2,
+        blockAllocator: nil,
+        customBlockSource: nil,
+        offsetToData: 0,
+        dataLength: 2,
+        flags: 0,
+        blockBufferOut: &blockBuffer
+    )
+    guard blockStatus == kCMBlockBufferNoErr, let blockBuffer else {
+        throw NSError(domain: "DLABCaptureTests", code: Int(blockStatus))
+    }
+
+    let zeroes = [UInt8](repeating: 0, count: 2)
+    let replaceStatus = CMBlockBufferReplaceDataBytes(
+        with: zeroes,
+        blockBuffer: blockBuffer,
+        offsetIntoDestination: 0,
+        dataLength: 2
+    )
+    guard replaceStatus == kCMBlockBufferNoErr else {
+        throw NSError(domain: "DLABCaptureTests", code: Int(replaceStatus))
+    }
+
+    var timingInfo = CMSampleTimingInfo(
+        duration: CMTime(value: 1, timescale: 48_000),
+        presentationTimeStamp: .zero,
+        decodeTimeStamp: .invalid
+    )
+    var sampleSize = 2
+    var sampleBuffer: CMSampleBuffer?
+    let sampleStatus = CMSampleBufferCreateReady(
+        allocator: kCFAllocatorDefault,
+        dataBuffer: blockBuffer,
+        formatDescription: formatDescription,
+        sampleCount: 1,
+        sampleTimingEntryCount: 1,
+        sampleTimingArray: &timingInfo,
+        sampleSizeEntryCount: 1,
+        sampleSizeArray: &sampleSize,
+        sampleBufferOut: &sampleBuffer
+    )
+    guard sampleStatus == noErr, let sampleBuffer else {
+        throw NSError(domain: "DLABCaptureTests", code: Int(sampleStatus))
+    }
+
+    return sampleBuffer
 }


### PR DESCRIPTION
## Summary

This PR consolidates the reviewed fixes for backlog items M-01, M-02, M-03, M-04, M-06, and M-14 in the DLAB Swift Package.

### Included fixes

- **M-01**: Surface `writer.appendSampleBuffer` failures via `lastAppendError`, `appendErrorCount`, `appendErrorMediaType`, and `clearLastAppendError()`
- **M-02**: Read `(currentDevice, running)` atomically in `captureStopAsync()`
- **M-03**: Surface `captureStartAsync()` and rollback failures via `lastStartError`, including the precondition failure path
- **M-04**: Guard `CaptureTimecodeHelper.extractCVSMPTETime` against undersized `NSData` attachments before `load(as:)`
- **M-06**: Document the `CaptureWriter.openSession()` concurrency / reentrancy contract without adding a naive in-flight flag
- **M-14**: Move `timecodeSource` behind synchronized storage and enforce the set-before-capture contract by ignoring runtime changes with a warning

## Validation

- `swift build`
- `swift test` (31 tests passed)

## Notes

The six fixes were implemented and reviewed independently first, then merged into this branch for PR submission.